### PR TITLE
Add offline badminton session manager

### DIFF
--- a/badminton-manifest.json
+++ b/badminton-manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Badminton Session Manager",
+  "short_name": "Badminton",
+  "start_url": "badminton.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Offline tool for organizing badminton courts",
+  "icons": []
+}

--- a/badminton.html
+++ b/badminton.html
@@ -13,7 +13,7 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 #queue {background:#d1ecf1;}
 #nextGame {background:#f8d7da;}
 .court {flex:1; background:#d4edda;}
-.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem;}
+.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; max-width:300px;}
 .player span {flex:1; min-width:0; max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 .container {display:flex; gap:1rem; overflow-x:auto;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}

--- a/badminton.html
+++ b/badminton.html
@@ -14,9 +14,11 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 #nextGame {background:#f8d7da;}
 .court {flex:1; background:#d4edda;}
 .player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem;}
+.player span {max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:inline-block;}
 .container {display:flex; gap:1rem;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}
-.player button.delete {margin-left:auto; background:none; border:none; cursor:pointer; color:#900;}
+.player button.toQueue, .player button.toNext {margin-left:auto;}
+.player button.delete {background:none; border:none; cursor:pointer; color:#900;}
 </style>
 </head>
 <body>

--- a/badminton.html
+++ b/badminton.html
@@ -18,7 +18,7 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 .drag-preview {position:fixed; pointer-events:none; background:#e0e0e0; padding:0.25rem 0.5rem; border:1px solid #999; border-radius:3px; z-index:1000;}
 .container {display:flex; gap:1rem; overflow-x:auto;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}
-.player button.toQueue, .player button.toNext {margin-left:auto;}
+.player button.toQueue, .player button.toNext, .player button.returnQueue {margin-left:auto;}
 .player button.delete {background:none; border:none; cursor:pointer; color:#900;}
 @media (max-width:600px) {
   body {padding:0.5rem;}

--- a/badminton.html
+++ b/badminton.html
@@ -13,12 +13,16 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 #queue {background:#d1ecf1;}
 #nextGame {background:#f8d7da;}
 .court {flex:1; background:#d4edda;}
-.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; width:300px;}
+.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; width:fit-content; max-width:300px;}
 .player span {flex:1; min-width:0; max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
-.container {display:flex; gap:1rem;}
+.container {display:flex; gap:1rem; overflow-x:auto;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}
 .player button.toQueue, .player button.toNext {margin-left:auto;}
 .player button.delete {background:none; border:none; cursor:pointer; color:#900;}
+@media (max-width:600px) {
+  body {padding:0.5rem;}
+  .container {gap:0.5rem;}
+}
 </style>
 </head>
 <body>

--- a/badminton.html
+++ b/badminton.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="manifest" href="badminton-manifest.json">
+<title>Badminton Session Manager</title>
+<style>
+body {font-family: Arial, sans-serif; margin:0; padding:1rem;}
+#queue, #staging, .court {border:1px solid #ccc; min-height:60px; padding:0.5rem; margin-bottom:1rem;}
+.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab;}
+.container {display:flex; flex-wrap:wrap; gap:1rem;}
+.court {flex:1 1 45%;}
+.court-title {font-weight:bold; margin-bottom:0.5rem;}
+</style>
+</head>
+<body>
+<h1>Badminton Session Manager</h1>
+<div>
+<label for="courtCount">Courts:</label>
+<select id="courtCount">
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+</select>
+</div>
+<div>
+<input id="playerName" placeholder="Player name">
+<button id="addPlayerBtn">Add Player</button>
+</div>
+<div id="queue" ondrop="drop(event)" ondragover="allowDrop(event)">
+<h3>Queue</h3>
+</div>
+<div class="container" id="courts"></div>
+<div id="staging" ondrop="drop(event)" ondragover="allowDrop(event)">
+<h3>Staging</h3>
+</div>
+<script src="badminton.js"></script>
+<script>
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('sw.js');
+}
+</script>
+</body>
+</html>

--- a/badminton.html
+++ b/badminton.html
@@ -7,10 +7,10 @@
 <title>Badminton Session Manager</title>
 <style>
 body {font-family: Arial, sans-serif; margin:0; padding:1rem;}
-#queue, #staging, .court {border:1px solid #ccc; min-height:60px; padding:0.5rem; margin-bottom:1rem;}
-.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab;}
-.container {display:flex; flex-wrap:wrap; gap:1rem;}
-.court {flex:1 1 45%;}
+#players, #queue, #nextGame, .court {border:1px solid #ccc; min-height:60px; padding:0.5rem; margin-bottom:1rem;}
+.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem;}
+.container {display:flex; gap:1rem;}
+.court {flex:1;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}
 </style>
 </head>
@@ -28,13 +28,16 @@ body {font-family: Arial, sans-serif; margin:0; padding:1rem;}
 <input id="playerName" placeholder="Player name">
 <button id="addPlayerBtn">Add Player</button>
 </div>
+<div id="players" ondrop="drop(event)" ondragover="allowDrop(event)">
+<h3>Players</h3>
+</div>
 <div id="queue" ondrop="drop(event)" ondragover="allowDrop(event)">
 <h3>Queue</h3>
 </div>
-<div class="container" id="courts"></div>
-<div id="staging" ondrop="drop(event)" ondragover="allowDrop(event)">
-<h3>Staging</h3>
+<div id="nextGame" ondrop="drop(event)" ondragover="allowDrop(event)">
+<h3>Next Game</h3>
 </div>
+<div class="container" id="courts"></div>
 <script src="badminton.js"></script>
 <script>
 if ('serviceWorker' in navigator) {

--- a/badminton.html
+++ b/badminton.html
@@ -7,11 +7,16 @@
 <title>Badminton Session Manager</title>
 <style>
 body {font-family: Arial, sans-serif; margin:0; padding:1rem;}
+h1 {font-size:1.5rem; margin:0.5rem 0;}
 #players, #queue, #nextGame, .court {border:1px solid #ccc; min-height:60px; padding:0.5rem; margin-bottom:1rem;}
+#players {background:#fff3cd;}
+#queue {background:#d1ecf1;}
+#nextGame {background:#f8d7da;}
+.court {flex:1; background:#d4edda;}
 .player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem;}
 .container {display:flex; gap:1rem;}
-.court {flex:1;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}
+.player button.delete {margin-left:auto; background:none; border:none; cursor:pointer; color:#900;}
 </style>
 </head>
 <body>
@@ -24,20 +29,16 @@ body {font-family: Arial, sans-serif; margin:0; padding:1rem;}
 <option value="4">4</option>
 </select>
 </div>
-<div>
-<input id="playerName" placeholder="Player name">
-<button id="addPlayerBtn">Add Player</button>
-</div>
-<div id="players" ondrop="drop(event)" ondragover="allowDrop(event)">
-<h3>Players</h3>
+<div class="container" id="courts"></div>
+<div id="nextGame" ondrop="drop(event)" ondragover="allowDrop(event)">
+<h3>Next Game</h3>
 </div>
 <div id="queue" ondrop="drop(event)" ondragover="allowDrop(event)">
 <h3>Queue</h3>
 </div>
-<div id="nextGame" ondrop="drop(event)" ondragover="allowDrop(event)">
-<h3>Next Game</h3>
+<div id="players" ondrop="drop(event)" ondragover="allowDrop(event)">
+<h3>Players</h3>
 </div>
-<div class="container" id="courts"></div>
 <script src="badminton.js"></script>
 <script>
 if ('serviceWorker' in navigator) {

--- a/badminton.html
+++ b/badminton.html
@@ -13,7 +13,7 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 #queue {background:#d1ecf1;}
 #nextGame {background:#f8d7da;}
 .court {flex:1; background:#d4edda;}
-.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; max-width:300px;}
+.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; touch-action:none; max-width:300px;}
 .player span {flex:1; min-width:0; max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 .container {display:flex; gap:1rem; overflow-x:auto;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}

--- a/badminton.html
+++ b/badminton.html
@@ -13,7 +13,7 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 #queue {background:#d1ecf1;}
 #nextGame {background:#f8d7da;}
 .court {flex:1; background:#d4edda;}
-.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; width:300px;}
+.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem;}
 .player span {flex:1; min-width:0; max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 .container {display:flex; gap:1rem; overflow-x:auto;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}

--- a/badminton.html
+++ b/badminton.html
@@ -13,7 +13,7 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 #queue {background:#d1ecf1;}
 #nextGame {background:#f8d7da;}
 .court {flex:1; background:#d4edda;}
-.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; width:fit-content; max-width:300px;}
+.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; width:300px;}
 .player span {flex:1; min-width:0; max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 .container {display:flex; gap:1rem; overflow-x:auto;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}

--- a/badminton.html
+++ b/badminton.html
@@ -15,6 +15,7 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 .court {flex:1; background:#d4edda;}
 .player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; touch-action:none; max-width:300px;}
 .player span {flex:1; min-width:0; max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
+.drag-preview {position:fixed; pointer-events:none; background:#e0e0e0; padding:0.25rem 0.5rem; border:1px solid #999; border-radius:3px; z-index:1000;}
 .container {display:flex; gap:1rem; overflow-x:auto;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}
 .player button.toQueue, .player button.toNext {margin-left:auto;}

--- a/badminton.html
+++ b/badminton.html
@@ -13,8 +13,8 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 #queue {background:#d1ecf1;}
 #nextGame {background:#f8d7da;}
 .court {flex:1; background:#d4edda;}
-.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem;}
-.player span {max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:inline-block;}
+.player {background:#e0e0e0; padding:0.25rem 0.5rem; margin:0.25rem; cursor:grab; display:flex; align-items:center; gap:0.25rem; width:300px;}
+.player span {flex:1; min-width:0; max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 .container {display:flex; gap:1rem;}
 .court-title {font-weight:bold; margin-bottom:0.5rem;}
 .player button.toQueue, .player button.toNext {margin-left:auto;}

--- a/badminton.html
+++ b/badminton.html
@@ -39,6 +39,7 @@ h1 {font-size:1.5rem; margin:0.5rem 0;}
 <div id="players" ondrop="drop(event)" ondragover="allowDrop(event)">
 <h3>Players</h3>
 </div>
+<button id="endSession">End Session</button>
 <script src="badminton.js"></script>
 <script>
 if ('serviceWorker' in navigator) {

--- a/badminton.js
+++ b/badminton.js
@@ -2,8 +2,6 @@ const playersEl = document.getElementById('players');
 const queueEl = document.getElementById('queue');
 const nextEl = document.getElementById('nextGame');
 const courtsEl = document.getElementById('courts');
-const playerInput = document.getElementById('playerName');
-const addBtn = document.getElementById('addPlayerBtn');
 const courtCountSelect = document.getElementById('courtCount');
 
 let state = JSON.parse(localStorage.getItem('badmintonState') || '{}');
@@ -21,10 +19,9 @@ function save() {
   localStorage.setItem('badmintonState', JSON.stringify(state));
 }
 
-function makePlayer(name, loc, idx1, idx2) {
+function makePlayer(name, loc, idx1, idx2, label) {
   const div = document.createElement('div');
   div.className = 'player';
-  div.textContent = name;
   div.draggable = true;
   div.dataset.location = loc;
   div.dataset.index1 = idx1;
@@ -36,13 +33,47 @@ function makePlayer(name, loc, idx1, idx2) {
     cb.className = 'select';
     cb.dataset.index = idx1;
     cb.onclick = e => e.stopPropagation();
-    div.prepend(cb);
+    div.appendChild(cb);
+  }
+  const span = document.createElement('span');
+  span.textContent = label || name;
+  div.appendChild(span);
+  if (loc === 'players') {
+    const del = document.createElement('button');
+    del.textContent = 'x';
+    del.className = 'delete';
+    del.onclick = e => {
+      e.stopPropagation();
+      state.players.splice(idx1, 1);
+      save();
+      render();
+    };
+    div.appendChild(del);
   }
   return div;
 }
 
 function render() {
   playersEl.innerHTML = '<h3>Players</h3>';
+  const addDiv = document.createElement('div');
+  const playerInput = document.createElement('input');
+  playerInput.id = 'playerName';
+  playerInput.placeholder = 'Player name';
+  const addBtn = document.createElement('button');
+  addBtn.id = 'addPlayerBtn';
+  addBtn.textContent = 'Add Player';
+  addDiv.appendChild(playerInput);
+  addDiv.appendChild(addBtn);
+  playersEl.appendChild(addDiv);
+  addBtn.onclick = () => {
+    const name = playerInput.value.trim();
+    if (name) {
+      state.players.push(name);
+      playerInput.value = '';
+      save();
+      render();
+    }
+  };
   state.players.forEach((p, i) => playersEl.appendChild(makePlayer(p, 'players', i)));
   const toQueueBtn = document.createElement('button');
   toQueueBtn.id = 'toQueueBtn';
@@ -57,7 +88,7 @@ function render() {
   };
 
   queueEl.innerHTML = '<h3>Queue</h3>';
-  state.queue.forEach((p, i) => queueEl.appendChild(makePlayer(p, 'queue', i)));
+  state.queue.forEach((p, i) => queueEl.appendChild(makePlayer(p, 'queue', i, undefined, `${i + 1}. ${p}`)));
   const toNextBtn = document.createElement('button');
   toNextBtn.id = 'toNextBtn';
   toNextBtn.textContent = 'Next Game';
@@ -143,16 +174,6 @@ function drop(e) {
   save();
   render();
 }
-
-addBtn.onclick = () => {
-  const name = playerInput.value.trim();
-  if (name) {
-    state.players.push(name);
-    playerInput.value = '';
-    save();
-    render();
-  }
-};
 
 courtCountSelect.onchange = () => {
   let n = parseInt(courtCountSelect.value, 10);

--- a/badminton.js
+++ b/badminton.js
@@ -1,5 +1,6 @@
+const playersEl = document.getElementById('players');
 const queueEl = document.getElementById('queue');
-const stagingEl = document.getElementById('staging');
+const nextEl = document.getElementById('nextGame');
 const courtsEl = document.getElementById('courts');
 const playerInput = document.getElementById('playerName');
 const addBtn = document.getElementById('addPlayerBtn');
@@ -7,10 +8,14 @@ const courtCountSelect = document.getElementById('courtCount');
 
 let state = JSON.parse(localStorage.getItem('badmintonState') || '{}');
 if (!state.players) state.players = [];
-if (!state.staging) state.staging = [];
+if (!state.queue) { state.queue = state.players; state.players = []; }
+if (!state.nextGame) { state.nextGame = state.staging || []; delete state.staging; }
 if (!state.courts) state.courts = [[], []]; // default 2 courts
 
 courtCountSelect.value = state.courts.length;
+
+playersEl.ondrop = queueEl.ondrop = nextEl.ondrop = drop;
+playersEl.ondragover = queueEl.ondragover = nextEl.ondragover = allowDrop;
 
 function save() {
   localStorage.setItem('badmintonState', JSON.stringify(state));
@@ -25,15 +30,50 @@ function makePlayer(name, loc, idx1, idx2) {
   div.dataset.index1 = idx1;
   if (idx2 !== undefined) div.dataset.index2 = idx2;
   div.ondragstart = drag;
+  if (loc === 'players' || loc === 'queue') {
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.className = 'select';
+    cb.dataset.index = idx1;
+    cb.onclick = e => e.stopPropagation();
+    div.prepend(cb);
+  }
   return div;
 }
 
 function render() {
-  queueEl.innerHTML = '<h3>Queue</h3>';
-  state.players.forEach((p, i) => queueEl.appendChild(makePlayer(p, 'players', i)));
+  playersEl.innerHTML = '<h3>Players</h3>';
+  state.players.forEach((p, i) => playersEl.appendChild(makePlayer(p, 'players', i)));
+  const toQueueBtn = document.createElement('button');
+  toQueueBtn.id = 'toQueueBtn';
+  toQueueBtn.textContent = 'To Queue';
+  playersEl.appendChild(toQueueBtn);
+  toQueueBtn.onclick = () => {
+    const selected = Array.from(playersEl.querySelectorAll('input.select:checked'))
+      .map(cb => parseInt(cb.dataset.index, 10)).sort((a, b) => b - a);
+    selected.forEach(idx => state.queue.push(state.players.splice(idx, 1)[0]));
+    save();
+    render();
+  };
 
-  stagingEl.innerHTML = '<h3>Staging</h3>';
-  state.staging.forEach((p, i) => stagingEl.appendChild(makePlayer(p, 'staging', i)));
+  queueEl.innerHTML = '<h3>Queue</h3>';
+  state.queue.forEach((p, i) => queueEl.appendChild(makePlayer(p, 'queue', i)));
+  const toNextBtn = document.createElement('button');
+  toNextBtn.id = 'toNextBtn';
+  toNextBtn.textContent = 'Next Game';
+  queueEl.appendChild(toNextBtn);
+  toNextBtn.onclick = () => {
+    const selected = Array.from(queueEl.querySelectorAll('input.select:checked'))
+      .map(cb => parseInt(cb.dataset.index, 10)).sort((a, b) => b - a);
+    selected.forEach(idx => {
+      if (state.nextGame.length < 4) state.nextGame.push(state.queue.splice(idx, 1)[0]);
+    });
+    save();
+    render();
+  };
+
+  nextEl.innerHTML = '<h3>Next Game</h3>';
+  state.nextGame.forEach((p, i) => nextEl.appendChild(makePlayer(p, 'next', i)));
 
   courtsEl.innerHTML = '';
   state.courts.forEach((court, i) => {
@@ -42,8 +82,23 @@ function render() {
     div.dataset.court = i;
     div.ondrop = drop;
     div.ondragover = allowDrop;
-    div.innerHTML = `<div class="court-title">Court ${i + 1}</div>`;
+    div.innerHTML = `<div class="court-title">Court ${i + 1} <button class="in">In</button> <button class="out">Out</button></div>`;
     court.forEach((p, j) => div.appendChild(makePlayer(p, 'courts', i, j)));
+    const inBtn = div.querySelector('.in');
+    const outBtn = div.querySelector('.out');
+    inBtn.onclick = () => {
+      if (state.courts[i].length === 0 && state.nextGame.length) {
+        state.courts[i] = state.nextGame.splice(0, 4);
+        save();
+        render();
+      }
+    };
+    outBtn.onclick = () => {
+      state.queue.push(...state.courts[i]);
+      state.courts[i] = [];
+      save();
+      render();
+    };
     courtsEl.appendChild(div);
   });
 }
@@ -66,20 +121,24 @@ function drop(e) {
   let name;
   if (data.location === 'players') {
     name = state.players.splice(data.index1, 1)[0];
-  } else if (data.location === 'staging') {
-    name = state.staging.splice(data.index1, 1)[0];
+  } else if (data.location === 'queue') {
+    name = state.queue.splice(data.index1, 1)[0];
+  } else if (data.location === 'next') {
+    name = state.nextGame.splice(data.index1, 1)[0];
   } else if (data.location === 'courts') {
     name = state.courts[data.index1].splice(data.index2, 1)[0];
   }
 
   const target = e.currentTarget;
-  if (target.id === 'queue') {
+  if (target.id === 'players') {
     state.players.push(name);
-  } else if (target.id === 'staging') {
-    if (state.staging.length < 4) state.staging.push(name); else state.players.push(name);
+  } else if (target.id === 'queue') {
+    state.queue.push(name);
+  } else if (target.id === 'nextGame') {
+    if (state.nextGame.length < 4) state.nextGame.push(name); else state.queue.push(name);
   } else if (target.classList.contains('court')) {
     const idx = target.dataset.court;
-    if (state.courts[idx].length < 4) state.courts[idx].push(name); else state.players.push(name);
+    if (state.courts[idx].length < 4) state.courts[idx].push(name); else state.queue.push(name);
   }
   save();
   render();

--- a/badminton.js
+++ b/badminton.js
@@ -22,6 +22,23 @@ function save() {
   localStorage.setItem('playerPool', JSON.stringify(pool));
 }
 
+function setPlayerWidths() {
+  const els = document.querySelectorAll('.player');
+  if (!els.length) return;
+  els.forEach(el => (el.style.width = 'auto'));
+  let maxName = 0;
+  let maxExtra = 0;
+  els.forEach(el => {
+    const span = el.querySelector('span');
+    const nameWidth = span.getBoundingClientRect().width;
+    if (nameWidth > maxName) maxName = nameWidth;
+    const extra = el.getBoundingClientRect().width - nameWidth;
+    if (extra > maxExtra) maxExtra = extra;
+  });
+  const total = Math.ceil(maxName + maxExtra);
+  els.forEach(el => (el.style.width = total + 'px'));
+}
+
 function makePlayer(name, loc, idx1, idx2, label) {
   const div = document.createElement('div');
   div.className = 'player';
@@ -204,6 +221,7 @@ function render() {
     };
     courtsEl.appendChild(div);
   });
+  setPlayerWidths();
 }
 
 function allowDrop(e) {
@@ -282,6 +300,7 @@ courtCountSelect.onchange = () => {
 };
 
 render();
+window.addEventListener('resize', setPlayerWidths);
 
 endSessionBtn.onclick = () => {
   const all = [

--- a/badminton.js
+++ b/badminton.js
@@ -42,6 +42,17 @@ function makePlayer(name, loc, idx1, idx2, label) {
   span.textContent = label || name;
   div.appendChild(span);
   if (loc === 'players') {
+    const toQueueBtn = document.createElement('button');
+    toQueueBtn.textContent = 'To Queue';
+    toQueueBtn.className = 'toQueue';
+    toQueueBtn.onclick = e => {
+      e.stopPropagation();
+      state.queue.push(state.players.splice(idx1, 1)[0]);
+      save();
+      render();
+    };
+    div.appendChild(toQueueBtn);
+
     const del = document.createElement('button');
     del.textContent = 'x';
     del.className = 'delete';
@@ -54,6 +65,19 @@ function makePlayer(name, loc, idx1, idx2, label) {
       render();
     };
     div.appendChild(del);
+  } else if (loc === 'queue') {
+    const nextBtn = document.createElement('button');
+    nextBtn.textContent = 'Next Game';
+    nextBtn.className = 'toNext';
+    nextBtn.onclick = e => {
+      e.stopPropagation();
+      if (state.nextGame.length < 4) {
+        state.nextGame.push(state.queue.splice(idx1, 1)[0]);
+        save();
+        render();
+      }
+    };
+    div.appendChild(nextBtn);
   }
   return div;
 }

--- a/badminton.js
+++ b/badminton.js
@@ -42,7 +42,7 @@ function setPlayerWidths() {
       const extra = el.getBoundingClientRect().width - nameWidth;
       if (extra > maxExtra) maxExtra = extra;
     });
-    const total = Math.ceil(maxName + maxExtra);
+    const total = Math.min(Math.ceil(maxName + maxExtra), 300);
     els.forEach(el => (el.style.width = total + 'px'));
   });
 }

--- a/badminton.js
+++ b/badminton.js
@@ -77,6 +77,10 @@ function render() {
   addDiv.appendChild(playerInput);
   addDiv.appendChild(addBtn);
   addDiv.appendChild(importBtn);
+  const toQueueBtn = document.createElement('button');
+  toQueueBtn.id = 'toQueueBtn';
+  toQueueBtn.textContent = 'To Queue';
+  addDiv.appendChild(toQueueBtn);
   playersEl.appendChild(addDiv);
   playersEl.appendChild(importInput);
   addBtn.onclick = () => {
@@ -107,10 +111,6 @@ function render() {
     render();
   };
   state.players.forEach((p, i) => playersEl.appendChild(makePlayer(p, 'players', i)));
-  const toQueueBtn = document.createElement('button');
-  toQueueBtn.id = 'toQueueBtn';
-  toQueueBtn.textContent = 'To Queue';
-  playersEl.appendChild(toQueueBtn);
   toQueueBtn.onclick = () => {
     const selected = Array.from(playersEl.querySelectorAll('input.select:checked'))
       .map(cb => parseInt(cb.dataset.index, 10)).sort((a, b) => b - a);

--- a/badminton.js
+++ b/badminton.js
@@ -190,6 +190,17 @@ function makePlayer(name, loc, idx1, idx2, label) {
       }
     };
     div.appendChild(nextBtn);
+  } else if (loc === 'next') {
+    const returnBtn = document.createElement('button');
+    returnBtn.textContent = 'Return to Queue';
+    returnBtn.className = 'returnQueue';
+    returnBtn.onclick = e => {
+      e.stopPropagation();
+      state.queue.unshift(state.nextGame.splice(idx1, 1)[0]);
+      save();
+      render();
+    };
+    div.appendChild(returnBtn);
   }
   return div;
 }
@@ -343,6 +354,7 @@ function drag(e) {
 
 function drop(e) {
   e.preventDefault();
+  removeDragPreview();
   const data = JSON.parse(e.dataTransfer.getData('text/plain'));
   const srcIdx1 = data.index1 !== undefined ? parseInt(data.index1, 10) : undefined;
   const srcIdx2 = data.index2 !== undefined ? parseInt(data.index2, 10) : undefined;

--- a/badminton.js
+++ b/badminton.js
@@ -94,6 +94,9 @@ function render() {
   const importBtn = document.createElement('button');
   importBtn.id = 'importPlayersBtn';
   importBtn.textContent = 'Import Players';
+  const exportBtn = document.createElement('button');
+  exportBtn.id = 'exportPlayersBtn';
+  exportBtn.textContent = 'Export Players';
   const importInput = document.createElement('input');
   importInput.type = 'file';
   importInput.accept = 'text/plain';
@@ -101,6 +104,7 @@ function render() {
   addDiv.appendChild(playerInput);
   addDiv.appendChild(addBtn);
   addDiv.appendChild(importBtn);
+  addDiv.appendChild(exportBtn);
   const toQueueBtn = document.createElement('button');
   toQueueBtn.id = 'toQueueBtn';
   toQueueBtn.textContent = 'To Queue';
@@ -134,6 +138,18 @@ function render() {
     save();
     render();
   };
+  exportBtn.onclick = () => {
+    const content = pool.join('\n');
+    const blob = new Blob([content], {type: 'text/plain'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'players.txt';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
   state.players.forEach((p, i) => playersEl.appendChild(makePlayer(p, 'players', i)));
   toQueueBtn.onclick = () => {
     const selected = Array.from(playersEl.querySelectorAll('input.select:checked'))
@@ -144,11 +160,11 @@ function render() {
   };
 
   queueEl.innerHTML = '<h3>Queue</h3>';
-  state.queue.forEach((p, i) => queueEl.appendChild(makePlayer(p, 'queue', i, undefined, `${i + 1}. ${p}`)));
   const toNextBtn = document.createElement('button');
   toNextBtn.id = 'toNextBtn';
   toNextBtn.textContent = 'Next Game';
   queueEl.appendChild(toNextBtn);
+  state.queue.forEach((p, i) => queueEl.appendChild(makePlayer(p, 'queue', i, undefined, `${i + 1}. ${p}`)));
   toNextBtn.onclick = () => {
     const selected = Array.from(queueEl.querySelectorAll('input.select:checked'))
       .map(cb => parseInt(cb.dataset.index, 10)).sort((a, b) => b - a);

--- a/badminton.js
+++ b/badminton.js
@@ -3,11 +3,13 @@ const queueEl = document.getElementById('queue');
 const nextEl = document.getElementById('nextGame');
 const courtsEl = document.getElementById('courts');
 const courtCountSelect = document.getElementById('courtCount');
+const endSessionBtn = document.getElementById('endSession');
 
+let pool = JSON.parse(localStorage.getItem('playerPool') || '[]');
 let state = JSON.parse(localStorage.getItem('badmintonState') || '{}');
-if (!state.players) state.players = [];
-if (!state.queue) { state.queue = state.players; state.players = []; }
-if (!state.nextGame) { state.nextGame = state.staging || []; delete state.staging; }
+if (!state.players) state.players = [...pool];
+if (!state.queue) state.queue = [];
+if (!state.nextGame) state.nextGame = [];
 if (!state.courts) state.courts = [[], []]; // default 2 courts
 
 courtCountSelect.value = state.courts.length;
@@ -17,6 +19,7 @@ playersEl.ondragover = queueEl.ondragover = nextEl.ondragover = allowDrop;
 
 function save() {
   localStorage.setItem('badmintonState', JSON.stringify(state));
+  localStorage.setItem('playerPool', JSON.stringify(pool));
 }
 
 function makePlayer(name, loc, idx1, idx2, label) {
@@ -44,7 +47,9 @@ function makePlayer(name, loc, idx1, idx2, label) {
     del.className = 'delete';
     del.onclick = e => {
       e.stopPropagation();
-      state.players.splice(idx1, 1);
+      const removed = state.players.splice(idx1, 1)[0];
+      const pIdx = pool.indexOf(removed);
+      if (pIdx !== -1) pool.splice(pIdx, 1);
       save();
       render();
     };
@@ -62,17 +67,44 @@ function render() {
   const addBtn = document.createElement('button');
   addBtn.id = 'addPlayerBtn';
   addBtn.textContent = 'Add Player';
+  const importBtn = document.createElement('button');
+  importBtn.id = 'importPlayersBtn';
+  importBtn.textContent = 'Import Players';
+  const importInput = document.createElement('input');
+  importInput.type = 'file';
+  importInput.accept = 'text/plain';
+  importInput.style.display = 'none';
   addDiv.appendChild(playerInput);
   addDiv.appendChild(addBtn);
+  addDiv.appendChild(importBtn);
   playersEl.appendChild(addDiv);
+  playersEl.appendChild(importInput);
   addBtn.onclick = () => {
     const name = playerInput.value.trim();
     if (name) {
-      state.players.push(name);
+      if (!pool.includes(name)) pool.push(name);
+      if (!state.players.includes(name) && !state.queue.includes(name) && !state.nextGame.includes(name) && !state.courts.some(c => c.includes(name))) {
+        state.players.push(name);
+      }
       playerInput.value = '';
       save();
       render();
     }
+  };
+  importBtn.onclick = () => importInput.click();
+  importInput.onchange = async () => {
+    const file = importInput.files[0];
+    if (!file) return;
+    const text = await file.text();
+    text.split(/\r?\n/).map(s => s.trim()).filter(Boolean).forEach(n => {
+      if (!pool.includes(n)) pool.push(n);
+      if (!state.players.includes(n) && !state.queue.includes(n) && !state.nextGame.includes(n) && !state.courts.some(c => c.includes(n))) {
+        state.players.push(n);
+      }
+    });
+    importInput.value = '';
+    save();
+    render();
   };
   state.players.forEach((p, i) => playersEl.appendChild(makePlayer(p, 'players', i)));
   const toQueueBtn = document.createElement('button');
@@ -184,3 +216,12 @@ courtCountSelect.onchange = () => {
 };
 
 render();
+
+endSessionBtn.onclick = () => {
+  state.players = [...pool];
+  state.queue = [];
+  state.nextGame = [];
+  state.courts = state.courts.map(() => []);
+  save();
+  render();
+};

--- a/badminton.js
+++ b/badminton.js
@@ -1,0 +1,106 @@
+const queueEl = document.getElementById('queue');
+const stagingEl = document.getElementById('staging');
+const courtsEl = document.getElementById('courts');
+const playerInput = document.getElementById('playerName');
+const addBtn = document.getElementById('addPlayerBtn');
+const courtCountSelect = document.getElementById('courtCount');
+
+let state = JSON.parse(localStorage.getItem('badmintonState') || '{}');
+if (!state.players) state.players = [];
+if (!state.staging) state.staging = [];
+if (!state.courts) state.courts = [[], []]; // default 2 courts
+
+courtCountSelect.value = state.courts.length;
+
+function save() {
+  localStorage.setItem('badmintonState', JSON.stringify(state));
+}
+
+function makePlayer(name, loc, idx1, idx2) {
+  const div = document.createElement('div');
+  div.className = 'player';
+  div.textContent = name;
+  div.draggable = true;
+  div.dataset.location = loc;
+  div.dataset.index1 = idx1;
+  if (idx2 !== undefined) div.dataset.index2 = idx2;
+  div.ondragstart = drag;
+  return div;
+}
+
+function render() {
+  queueEl.innerHTML = '<h3>Queue</h3>';
+  state.players.forEach((p, i) => queueEl.appendChild(makePlayer(p, 'players', i)));
+
+  stagingEl.innerHTML = '<h3>Staging</h3>';
+  state.staging.forEach((p, i) => stagingEl.appendChild(makePlayer(p, 'staging', i)));
+
+  courtsEl.innerHTML = '';
+  state.courts.forEach((court, i) => {
+    const div = document.createElement('div');
+    div.className = 'court';
+    div.dataset.court = i;
+    div.ondrop = drop;
+    div.ondragover = allowDrop;
+    div.innerHTML = `<div class="court-title">Court ${i + 1}</div>`;
+    court.forEach((p, j) => div.appendChild(makePlayer(p, 'courts', i, j)));
+    courtsEl.appendChild(div);
+  });
+}
+
+function allowDrop(e) {
+  e.preventDefault();
+}
+
+function drag(e) {
+  e.dataTransfer.setData('text/plain', JSON.stringify({
+    location: e.target.dataset.location,
+    index1: e.target.dataset.index1,
+    index2: e.target.dataset.index2
+  }));
+}
+
+function drop(e) {
+  e.preventDefault();
+  const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+  let name;
+  if (data.location === 'players') {
+    name = state.players.splice(data.index1, 1)[0];
+  } else if (data.location === 'staging') {
+    name = state.staging.splice(data.index1, 1)[0];
+  } else if (data.location === 'courts') {
+    name = state.courts[data.index1].splice(data.index2, 1)[0];
+  }
+
+  const target = e.currentTarget;
+  if (target.id === 'queue') {
+    state.players.push(name);
+  } else if (target.id === 'staging') {
+    if (state.staging.length < 4) state.staging.push(name); else state.players.push(name);
+  } else if (target.classList.contains('court')) {
+    const idx = target.dataset.court;
+    if (state.courts[idx].length < 4) state.courts[idx].push(name); else state.players.push(name);
+  }
+  save();
+  render();
+}
+
+addBtn.onclick = () => {
+  const name = playerInput.value.trim();
+  if (name) {
+    state.players.push(name);
+    playerInput.value = '';
+    save();
+    render();
+  }
+};
+
+courtCountSelect.onchange = () => {
+  let n = parseInt(courtCountSelect.value, 10);
+  state.courts = state.courts.slice(0, n);
+  while (state.courts.length < n) state.courts.push([]);
+  save();
+  render();
+};
+
+render();

--- a/badminton.js
+++ b/badminton.js
@@ -17,6 +17,62 @@ courtCountSelect.value = state.courts.length;
 playersEl.ondrop = queueEl.ondrop = nextEl.ondrop = drop;
 playersEl.ondragover = queueEl.ondragover = nextEl.ondragover = allowDrop;
 
+let touchDragData = null;
+let touchTimer = null;
+let touchStartX = 0;
+let touchStartY = 0;
+let pendingTouchData = null;
+
+function handleTouchStart(e) {
+  if (e.target.tagName === 'BUTTON' || e.target.tagName === 'INPUT') return;
+  const el = e.currentTarget;
+  const touch = e.touches[0];
+  touchStartX = touch.clientX;
+  touchStartY = touch.clientY;
+  pendingTouchData = {
+    location: el.dataset.location,
+    index1: el.dataset.index1,
+    index2: el.dataset.index2
+  };
+  touchTimer = setTimeout(() => {
+    touchDragData = pendingTouchData;
+  }, 300);
+}
+
+function handleTouchMove(e) {
+  if (touchTimer) {
+    const touch = e.touches[0];
+    if (Math.abs(touch.clientX - touchStartX) > 10 || Math.abs(touch.clientY - touchStartY) > 10) {
+      clearTimeout(touchTimer);
+      touchTimer = null;
+      pendingTouchData = null;
+    }
+  }
+  if (touchDragData) e.preventDefault();
+}
+
+function handleTouchEnd(e) {
+  clearTimeout(touchTimer);
+  touchTimer = null;
+  if (!touchDragData) {
+    pendingTouchData = null;
+    return;
+  }
+  const touch = e.changedTouches[0];
+  const target = document.elementFromPoint(touch.clientX, touch.clientY);
+  const container = target && target.closest('#players, #queue, #nextGame, .court');
+  if (container) {
+    drop({
+      preventDefault: () => {},
+      currentTarget: container,
+      target,
+      dataTransfer: { getData: () => JSON.stringify(touchDragData) }
+    });
+  }
+  touchDragData = null;
+  pendingTouchData = null;
+}
+
 function save() {
   localStorage.setItem('badmintonState', JSON.stringify(state));
   localStorage.setItem('playerPool', JSON.stringify(pool));
@@ -55,6 +111,7 @@ function makePlayer(name, loc, idx1, idx2, label) {
   div.dataset.index1 = idx1;
   if (idx2 !== undefined) div.dataset.index2 = idx2;
   div.ondragstart = drag;
+  div.addEventListener('touchstart', handleTouchStart, {passive:true});
   if (loc === 'players' || loc === 'queue') {
     const cb = document.createElement('input');
     cb.type = 'checkbox';
@@ -309,6 +366,9 @@ courtCountSelect.onchange = () => {
 
 render();
 window.addEventListener('resize', setPlayerWidths);
+window.addEventListener('touchmove', handleTouchMove, {passive:false});
+window.addEventListener('touchend', handleTouchEnd);
+window.addEventListener('touchcancel', handleTouchEnd);
 
 endSessionBtn.onclick = () => {
   const all = [

--- a/badminton.js
+++ b/badminton.js
@@ -181,27 +181,53 @@ function drag(e) {
 function drop(e) {
   e.preventDefault();
   const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+  const srcIdx1 = data.index1 !== undefined ? parseInt(data.index1, 10) : undefined;
+  const srcIdx2 = data.index2 !== undefined ? parseInt(data.index2, 10) : undefined;
   let name;
   if (data.location === 'players') {
-    name = state.players.splice(data.index1, 1)[0];
+    name = state.players.splice(srcIdx1, 1)[0];
   } else if (data.location === 'queue') {
-    name = state.queue.splice(data.index1, 1)[0];
+    name = state.queue.splice(srcIdx1, 1)[0];
   } else if (data.location === 'next') {
-    name = state.nextGame.splice(data.index1, 1)[0];
+    name = state.nextGame.splice(srcIdx1, 1)[0];
   } else if (data.location === 'courts') {
-    name = state.courts[data.index1].splice(data.index2, 1)[0];
+    name = state.courts[srcIdx1].splice(srcIdx2, 1)[0];
   }
 
-  const target = e.currentTarget;
-  if (target.id === 'players') {
-    state.players.push(name);
-  } else if (target.id === 'queue') {
-    state.queue.push(name);
-  } else if (target.id === 'nextGame') {
-    if (state.nextGame.length < 4) state.nextGame.push(name); else state.queue.push(name);
-  } else if (target.classList.contains('court')) {
-    const idx = target.dataset.court;
-    if (state.courts[idx].length < 4) state.courts[idx].push(name); else state.queue.push(name);
+  const container = e.currentTarget;
+  const players = Array.from(container.querySelectorAll('.player'));
+  const dropTarget = e.target.closest('.player');
+  let dropIndex = players.length;
+  if (dropTarget && dropTarget.parentElement === container) {
+    dropIndex = players.indexOf(dropTarget);
+  }
+
+  const sameContainer =
+    (data.location === 'players' && container.id === 'players') ||
+    (data.location === 'queue' && container.id === 'queue') ||
+    (data.location === 'next' && container.id === 'nextGame') ||
+    (data.location === 'courts' && container.classList.contains('court') && parseInt(container.dataset.court, 10) === srcIdx1);
+
+  const sourceIndex = data.location === 'courts' ? srcIdx2 : srcIdx1;
+  if (sameContainer && dropIndex > sourceIndex) dropIndex--;
+
+  if (container.id === 'players') {
+    state.players.splice(dropIndex, 0, name);
+  } else if (container.id === 'queue') {
+    state.queue.splice(dropIndex, 0, name);
+  } else if (container.id === 'nextGame') {
+    if (state.nextGame.length < 4) {
+      state.nextGame.splice(dropIndex, 0, name);
+    } else {
+      state.queue.push(name);
+    }
+  } else if (container.classList.contains('court')) {
+    const idx = container.dataset.court;
+    if (state.courts[idx].length < 4) {
+      state.courts[idx].splice(dropIndex, 0, name);
+    } else {
+      state.queue.push(name);
+    }
   }
   save();
   render();
@@ -218,6 +244,13 @@ courtCountSelect.onchange = () => {
 render();
 
 endSessionBtn.onclick = () => {
+  const all = [
+    ...state.players,
+    ...state.queue,
+    ...state.nextGame,
+    ...state.courts.flat()
+  ];
+  pool = Array.from(new Set([...pool, ...all]));
   state.players = [...pool];
   state.queue = [];
   state.nextGame = [];

--- a/badminton.js
+++ b/badminton.js
@@ -22,6 +22,7 @@ let touchTimer = null;
 let touchStartX = 0;
 let touchStartY = 0;
 let pendingTouchData = null;
+let dragPreview = null;
 
 function handleTouchStart(e) {
   if (e.target.tagName === 'BUTTON' || e.target.tagName === 'INPUT') return;
@@ -36,6 +37,9 @@ function handleTouchStart(e) {
   };
   touchTimer = setTimeout(() => {
     touchDragData = pendingTouchData;
+    const name = el.querySelector('span').textContent;
+    createDragPreview(name);
+    moveDragPreview(touchStartX, touchStartY);
   }, 300);
 }
 
@@ -48,7 +52,11 @@ function handleTouchMove(e) {
       pendingTouchData = null;
     }
   }
-  if (touchDragData) e.preventDefault();
+  if (touchDragData) {
+    const touch = e.touches[0];
+    moveDragPreview(touch.clientX, touch.clientY);
+    e.preventDefault();
+  }
 }
 
 function handleTouchEnd(e) {
@@ -71,11 +79,33 @@ function handleTouchEnd(e) {
   }
   touchDragData = null;
   pendingTouchData = null;
+  removeDragPreview();
 }
 
 function save() {
   localStorage.setItem('badmintonState', JSON.stringify(state));
   localStorage.setItem('playerPool', JSON.stringify(pool));
+}
+
+function createDragPreview(text) {
+  dragPreview = document.createElement('div');
+  dragPreview.className = 'drag-preview';
+  dragPreview.textContent = text;
+  document.body.appendChild(dragPreview);
+}
+
+function moveDragPreview(x, y) {
+  if (dragPreview) {
+    dragPreview.style.left = x + 'px';
+    dragPreview.style.top = y + 'px';
+  }
+}
+
+function removeDragPreview() {
+  if (dragPreview) {
+    document.body.removeChild(dragPreview);
+    dragPreview = null;
+  }
 }
 
 function setPlayerWidths() {
@@ -294,11 +324,21 @@ function allowDrop(e) {
 }
 
 function drag(e) {
+  const text = e.target.querySelector('span').textContent;
+  createDragPreview(text);
+  // hide preview element off-screen for desktop drag image
+  dragPreview.style.left = '-9999px';
+  dragPreview.style.top = '-9999px';
+  e.dataTransfer.setDragImage(dragPreview, 0, 0);
   e.dataTransfer.setData('text/plain', JSON.stringify({
     location: e.target.dataset.location,
     index1: e.target.dataset.index1,
     index2: e.target.dataset.index2
   }));
+  e.target.ondragend = () => {
+    removeDragPreview();
+    e.target.ondragend = null;
+  };
 }
 
 function drop(e) {

--- a/badminton.js
+++ b/badminton.js
@@ -23,20 +23,28 @@ function save() {
 }
 
 function setPlayerWidths() {
-  const els = document.querySelectorAll('.player');
-  if (!els.length) return;
-  els.forEach(el => (el.style.width = 'auto'));
-  let maxName = 0;
-  let maxExtra = 0;
-  els.forEach(el => {
-    const span = el.querySelector('span');
-    const nameWidth = span.getBoundingClientRect().width;
-    if (nameWidth > maxName) maxName = nameWidth;
-    const extra = el.getBoundingClientRect().width - nameWidth;
-    if (extra > maxExtra) maxExtra = extra;
+  const containers = [
+    playersEl,
+    queueEl,
+    nextEl,
+    ...document.querySelectorAll('.court')
+  ];
+  containers.forEach(container => {
+    const els = container.querySelectorAll('.player');
+    if (!els.length) return;
+    els.forEach(el => (el.style.width = 'auto'));
+    let maxName = 0;
+    let maxExtra = 0;
+    els.forEach(el => {
+      const span = el.querySelector('span');
+      const nameWidth = span.getBoundingClientRect().width;
+      if (nameWidth > maxName) maxName = nameWidth;
+      const extra = el.getBoundingClientRect().width - nameWidth;
+      if (extra > maxExtra) maxExtra = extra;
+    });
+    const total = Math.ceil(maxName + maxExtra);
+    els.forEach(el => (el.style.width = total + 'px'));
   });
-  const total = Math.ceil(maxName + maxExtra);
-  els.forEach(el => (el.style.width = total + 'px'));
 }
 
 function makePlayer(name, loc, idx1, idx2, label) {

--- a/index.html
+++ b/index.html
@@ -2,9 +2,10 @@
 <html>
 <head>
 <meta name="google-site-verification" content="3yUtW8qlcctMLm_lgX-0GLQL7draGdwHO0ZR3BxQ_2c" />
-  </head>
- <body>
+</head>
+<body>
 <h1>Hello World</h1>
 <p>I'm hosted with GitHub Pages.</p>
+<p><a href="badminton.html">Open Badminton Session Manager</a></p>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'badminton-cache-v1';
+const ASSETS = [
+  '/',
+  '/badminton.html',
+  '/badminton.js',
+  '/badminton-manifest.json',
+  '/sw.js'
+];
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- Add `badminton.html` as an offline-capable badminton session manager with drag-and-drop courts and queue.
- Persist player and court state in `badminton.js` using `localStorage`.
- Register `sw.js` and include a manifest for offline support; add link from homepage.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check badminton.js`


------
https://chatgpt.com/codex/tasks/task_e_6897f06ef0dc8331b43d804269ed6d4c