### PR TITLE
Add avatar voice chatbot demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,12 +305,18 @@
       gap: 10px;
     }
 
-    .preview-grid img, .preview-grid audio {
+    .preview-grid img, .preview-grid audio, .preview-grid video {
       width: 100%;
       border-radius: 10px;
       border: 1px solid var(--panel-strong);
       background: rgba(0, 0, 0, 0.2);
     }
+
+    #avatarVideo {
+      z-index: 1;
+      pointer-events: none;
+    }
+    
 
     .toggle-row {
       display: flex;
@@ -386,6 +392,7 @@
       </div>
       <div class="status" id="micStatus">Voice input not started.</div>
       <div class="status" id="trainSummary">No training samples yet.</div>
+      <div class="status" id="renderStatus">Video render studio is idle.</div>
     </section>
 
     <section class="card stack">
@@ -408,9 +415,17 @@
         <div class="preview-grid" id="voicePreview"></div>
       </div>
 
+      <div class="upload-box">
+        <strong>Video samples</strong>
+        <p class="status">MP4 or WebM. Use short clips to drive lip sync and on-camera realism.</p>
+        <input id="videoInput" type="file" accept="video/*" multiple />
+        <div class="preview-grid" id="videoPreview"></div>
+      </div>
+
       <div class="stack">
         <button id="trainButton">Run quick training pass</button>
         <div class="status" id="trainStatus">Idle · waiting for uploads.</div>
+        <button id="renderButton" class="secondary">Render 8s talking avatar clip</button>
       </div>
     </section>
   </div>
@@ -433,6 +448,10 @@
     const trainButton = document.getElementById('trainButton');
     const trainStatus = document.getElementById('trainStatus');
     const trainSummary = document.getElementById('trainSummary');
+    const renderButton = document.getElementById('renderButton');
+    const renderStatus = document.getElementById('renderStatus');
+    const videoInput = document.getElementById('videoInput');
+    const videoPreview = document.getElementById('videoPreview');
 
     let recognition;
     let listening = false;
@@ -442,6 +461,8 @@
       voices: [],
       iterations: 0,
       voiceProfile: null,
+      videos: [],
+      lastRender: null,
     };
 
     let currentVoice;
@@ -480,13 +501,17 @@
     function respond(userText) {
       const photoNote = training.photos.length ? `${training.photos.length} photo${training.photos.length > 1 ? 's' : ''}` : 'no photos yet';
       const voiceNote = training.voiceProfile ? `voice tuned to ${training.voiceProfile.name}` : 'default voice';
+      const videoNote = training.videos.length ? `${training.videos.length} motion clip${training.videos.length > 1 ? 's' : ''} loaded for lip sync` : 'no motion clips yet';
       const presenceIntro = training.photos.length
         ? 'I am mirroring the face you trained me with so you feel a real presence beside you.'
         : 'Upload a photo to let me mirror your look while we talk.';
       const persona = training.voiceProfile
         ? `I am speaking with the tone of “${training.voiceProfile.name}” so it sounds like someone you know.`
         : 'I will switch to your custom tone once you upload a voice sample.';
-      const response = `${presenceIntro} ${persona} I heard: "${userText}". I am using ${voiceNote} and imagining your ${photoNote}.`;
+      const synthesiaLine = training.videos.length
+        ? 'I can render a HeyGen/Synthesia-style talking head clip from your uploaded video pose and photo look.'
+        : 'Add a short video clip so I can animate an AI avatar clip like HeyGen or Synthesia.';
+      const response = `${presenceIntro} ${persona} ${synthesiaLine} I heard: "${userText}". I am using ${voiceNote}, imagining your ${photoNote}, and synced to ${videoNote}.`;
       appendMessage(response, 'bot');
       speak(response);
     }
@@ -532,7 +557,9 @@
     function refreshTrainSummary() {
       const photoText = `${training.photos.length} photo sample${training.photos.length === 1 ? '' : 's'}`;
       const voiceText = training.voiceProfile ? `voice tuned to ${training.voiceProfile.name}` : `${training.voices.length} voice sample${training.voices.length === 1 ? '' : 's'}`;
-      trainSummary.textContent = `Prepared with ${photoText} and ${voiceText}. Training runs: ${training.iterations}.`;
+      const videoText = `${training.videos.length} video sample${training.videos.length === 1 ? '' : 's'}`;
+      const renderText = training.lastRender ? `Last render: ${training.lastRender}` : 'No renders yet';
+      trainSummary.textContent = `Prepared with ${photoText}, ${voiceText}, and ${videoText}. Training runs: ${training.iterations}. ${renderText}.`;
     }
 
     function handlePhotoUpload(files) {
@@ -578,6 +605,45 @@
         reader.readAsDataURL(file);
       });
       selectVoiceProfile();
+    }
+
+    function handleVideoUpload(files) {
+      videoPreview.innerHTML = '';
+      Array.from(files).forEach((file, index) => {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const video = document.createElement('video');
+          video.src = e.target.result;
+          video.controls = true;
+          video.muted = true;
+          video.loop = true;
+          videoPreview.appendChild(video);
+          training.videos.push({ name: file.name.replace(/\.[^/.]+$/, ''), src: e.target.result, mood: index % 2 ? 'confident' : 'warm' });
+          // The last video drives the avatar presence for Synthesia/HeyGen style demos.
+          if (index === files.length - 1) {
+            avatarImg.src = '';
+            if (!document.getElementById('avatarVideo')) {
+              const vid = document.createElement('video');
+              vid.id = 'avatarVideo';
+              vid.autoplay = true;
+              vid.loop = true;
+              vid.muted = true;
+              vid.playsInline = true;
+              vid.style.position = 'absolute';
+              vid.style.inset = '0';
+              vid.style.width = '100%';
+              vid.style.height = '100%';
+              vid.style.objectFit = 'cover';
+              avatarFrame.appendChild(vid);
+            }
+            const avatarVideo = document.getElementById('avatarVideo');
+            avatarVideo.src = e.target.result;
+            avatarVideo.play().catch(() => {});
+          }
+          refreshTrainSummary();
+        };
+        reader.readAsDataURL(file);
+      });
     }
 
     function wireRecognition() {
@@ -643,9 +709,14 @@
       handleVoiceUpload(e.target.files);
     });
 
+    videoInput.addEventListener('change', (e) => {
+      training.videos = [];
+      handleVideoUpload(e.target.files);
+    });
+
     trainButton.addEventListener('click', () => {
-      if (!training.photos.length && !training.voices.length) {
-        trainStatus.textContent = 'Add at least one photo or voice sample to train.';
+      if (!training.photos.length && !training.voices.length && !training.videos.length) {
+        trainStatus.textContent = 'Add at least one photo, video, or voice sample to train.';
         trainStatus.style.color = 'var(--danger)';
         return;
       }
@@ -658,6 +729,33 @@
         trainButton.disabled = false;
         refreshTrainSummary();
       }, 900);
+    });
+
+    renderButton.addEventListener('click', () => {
+      if (!training.photos.length && !training.videos.length && !training.voiceProfile) {
+        renderStatus.textContent = 'Add video, photo, or voice samples to drive the avatar before rendering.';
+        renderStatus.style.color = 'var(--danger)';
+        return;
+      }
+      renderStatus.style.color = 'var(--muted)';
+      renderStatus.textContent = 'Rendering 8s talking avatar clip (simulated)...';
+      renderButton.disabled = true;
+      let progress = 0;
+      const timer = setInterval(() => {
+        progress += 20;
+        renderStatus.textContent = `Synthesizing face sync · ${progress}%`;
+        if (progress >= 100) {
+          clearInterval(timer);
+          const chosenMood = training.videos[training.videos.length - 1]?.mood || 'friendly';
+          const look = training.photos.length ? 'your uploaded photos' : 'the default look';
+          const tone = training.voiceProfile ? `voice "${training.voiceProfile.name}"` : 'default voice';
+          const label = `Render ${new Date().toLocaleTimeString()}`;
+          training.lastRender = label;
+          renderStatus.textContent = `Rendered clip using ${look}, ${tone}, mood ${chosenMood}. (${label})`;
+          renderButton.disabled = false;
+          refreshTrainSummary();
+        }
+      }, 320);
     });
 
     ttsPill.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -397,6 +397,20 @@
 
     <section class="card stack">
       <div>
+        <h2>AI backend connection</h2>
+        <small>Point the studio at a real inference and training service to power live generation.</small>
+      </div>
+      <div class="upload-box">
+        <strong>Service base URL</strong>
+        <p class="status">Example: https://your-api.example.com. All chat and training calls are sent here.</p>
+        <input id="apiBaseInput" type="text" placeholder="https://api.your-llm.com" />
+        <strong style="display:block;margin-top:10px;">API key (stored locally)</strong>
+        <p class="status">Used in the Authorization header for real model + training calls.</p>
+        <input id="apiKeyInput" type="text" placeholder="sk-..." />
+        <div class="status" id="apiStatus">No backend configured. Calls will stay local.</div>
+      </div>
+
+      <div>
         <h2>Avatar & Voice Trainer</h2>
         <small>Upload reference photos and voice clips to personalize the chatbot's appearance and tone.</small>
       </div>
@@ -452,10 +466,20 @@
     const renderStatus = document.getElementById('renderStatus');
     const videoInput = document.getElementById('videoInput');
     const videoPreview = document.getElementById('videoPreview');
+    const apiBaseInput = document.getElementById('apiBaseInput');
+    const apiKeyInput = document.getElementById('apiKeyInput');
+    const apiStatus = document.getElementById('apiStatus');
 
     let recognition;
     let listening = false;
     let speechOutput = true;
+    const backend = {
+      baseUrl: '',
+      apiKey: '',
+      modelId: null,
+      avatarUrl: null,
+      voiceId: null,
+    };
     const training = {
       photos: [],
       voices: [],
@@ -464,6 +488,8 @@
       videos: [],
       lastRender: null,
     };
+
+    const messages = [];
 
     let currentVoice;
     let speaking = false;
@@ -474,6 +500,7 @@
       message.textContent = text;
       chatLog.appendChild(message);
       chatLog.scrollTop = chatLog.scrollHeight;
+      return message;
     }
 
     function setSpeaking(state) {
@@ -498,28 +525,73 @@
       window.speechSynthesis.speak(utterance);
     }
 
-    function respond(userText) {
-      const photoNote = training.photos.length ? `${training.photos.length} photo${training.photos.length > 1 ? 's' : ''}` : 'no photos yet';
-      const voiceNote = training.voiceProfile ? `voice tuned to ${training.voiceProfile.name}` : 'default voice';
-      const videoNote = training.videos.length ? `${training.videos.length} motion clip${training.videos.length > 1 ? 's' : ''} loaded for lip sync` : 'no motion clips yet';
-      const presenceIntro = training.photos.length
-        ? 'I am mirroring the face you trained me with so you feel a real presence beside you.'
-        : 'Upload a photo to let me mirror your look while we talk.';
-      const persona = training.voiceProfile
-        ? `I am speaking with the tone of “${training.voiceProfile.name}” so it sounds like someone you know.`
-        : 'I will switch to your custom tone once you upload a voice sample.';
-      const synthesiaLine = training.videos.length
-        ? 'I can render a HeyGen/Synthesia-style talking head clip from your uploaded video pose and photo look.'
-        : 'Add a short video clip so I can animate an AI avatar clip like HeyGen or Synthesia.';
-      const response = `${presenceIntro} ${persona} ${synthesiaLine} I heard: "${userText}". I am using ${voiceNote}, imagining your ${photoNote}, and synced to ${videoNote}.`;
-      appendMessage(response, 'bot');
-      speak(response);
+    async function respond(userText) {
+      const pending = appendMessage('Thinking with your custom model…', 'bot');
+      const payload = {
+        prompt: userText,
+        conversation: messages.slice(-10),
+        modelId: backend.modelId,
+        voiceId: backend.voiceId,
+        avatarUrl: backend.avatarUrl,
+        photoCount: training.photos.length,
+        voiceCount: training.voices.length,
+        videoCount: training.videos.length,
+      };
+
+      async function runLocalFallback() {
+        const photoNote = training.photos.length ? `${training.photos.length} photo${training.photos.length > 1 ? 's' : ''}` : 'no photos yet';
+        const voiceNote = training.voiceProfile ? `voice tuned to ${training.voiceProfile.name}` : 'default voice';
+        const videoNote = training.videos.length ? `${training.videos.length} motion clip${training.videos.length > 1 ? 's' : ''} loaded for lip sync` : 'no motion clips yet';
+        const response = `Backend not configured—responding locally. You said: "${userText}". Using ${photoNote}, ${voiceNote}, and ${videoNote} to shape the reply.`;
+        pending.textContent = response;
+        messages.push({ role: 'assistant', content: response });
+        speak(response);
+      }
+
+      if (!backend.baseUrl) {
+        await runLocalFallback();
+        return;
+      }
+
+      try {
+        const url = backend.baseUrl.replace(/\/$/, '') + '/chat';
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(backend.apiKey ? { Authorization: `Bearer ${backend.apiKey}` } : {}),
+          },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) throw new Error(`Chat request failed: ${res.status}`);
+        const data = await res.json();
+        const reply = data.reply || data.response || 'No text returned from the model.';
+        pending.textContent = reply;
+        messages.push({ role: 'assistant', content: reply });
+        if (data.avatarUrl) {
+          backend.avatarUrl = data.avatarUrl;
+          setAvatarPreview(data.avatarUrl);
+        }
+        if (data.audioUrl) {
+          const player = new Audio(data.audioUrl);
+          player.onplay = () => setSpeaking(true);
+          player.onended = () => setSpeaking(false);
+          player.onerror = () => setSpeaking(false);
+          await player.play().catch(() => speak(reply));
+        } else {
+          speak(reply);
+        }
+      } catch (err) {
+        pending.textContent = `Realtime model call failed: ${err.message}. Falling back locally.`;
+        await runLocalFallback();
+      }
     }
 
     function handleSend() {
       const text = chatInput.value.trim();
       if (!text) return;
       appendMessage(text, 'user');
+      messages.push({ role: 'user', content: text });
       chatInput.value = '';
       respond(text);
     }
@@ -554,6 +626,32 @@
       avatarImg.src = src;
     }
 
+    function saveBackendConfig() {
+      backend.baseUrl = apiBaseInput.value.trim();
+      backend.apiKey = apiKeyInput.value.trim();
+      localStorage.setItem('avatarStudioBackend', JSON.stringify({ baseUrl: backend.baseUrl, apiKey: backend.apiKey }));
+      apiStatus.textContent = backend.baseUrl
+        ? `Using ${backend.baseUrl} for chat + training calls.`
+        : 'No backend configured. Calls will stay local.';
+    }
+
+    function loadBackendConfig() {
+      const raw = localStorage.getItem('avatarStudioBackend');
+      if (!raw) return;
+      try {
+        const parsed = JSON.parse(raw);
+        backend.baseUrl = parsed.baseUrl || '';
+        backend.apiKey = parsed.apiKey || '';
+        apiBaseInput.value = backend.baseUrl;
+        apiKeyInput.value = backend.apiKey;
+        apiStatus.textContent = backend.baseUrl
+          ? `Using ${backend.baseUrl} for chat + training calls.`
+          : 'No backend configured. Calls will stay local.';
+      } catch (e) {
+        console.warn('Failed to load backend config', e);
+      }
+    }
+
     function refreshTrainSummary() {
       const photoText = `${training.photos.length} photo sample${training.photos.length === 1 ? '' : 's'}`;
       const voiceText = training.voiceProfile ? `voice tuned to ${training.voiceProfile.name}` : `${training.voices.length} voice sample${training.voices.length === 1 ? '' : 's'}`;
@@ -570,7 +668,7 @@
           const img = document.createElement('img');
           img.src = e.target.result;
           photoPreview.appendChild(img);
-          training.photos.push(e.target.result);
+          training.photos.push({ src: e.target.result, file });
           setAvatarPreview(e.target.result);
           refreshTrainSummary();
         };
@@ -597,6 +695,7 @@
             src: e.target.result,
             pitch: 1 + index * 0.03,
             rate: 1 - index * 0.02,
+            file,
           };
           training.voices.push(signature);
           training.voiceProfile = signature;
@@ -618,7 +717,7 @@
           video.muted = true;
           video.loop = true;
           videoPreview.appendChild(video);
-          training.videos.push({ name: file.name.replace(/\.[^/.]+$/, ''), src: e.target.result, mood: index % 2 ? 'confident' : 'warm' });
+          training.videos.push({ name: file.name.replace(/\.[^/.]+$/, ''), src: e.target.result, file, mood: index % 2 ? 'confident' : 'warm' });
           // The last video drives the avatar presence for Synthesia/HeyGen style demos.
           if (index === files.length - 1) {
             avatarImg.src = '';
@@ -699,6 +798,9 @@
       }
     });
 
+    apiBaseInput.addEventListener('change', saveBackendConfig);
+    apiKeyInput.addEventListener('change', saveBackendConfig);
+
     photoInput.addEventListener('change', (e) => {
       training.photos = [];
       handlePhotoUpload(e.target.files);
@@ -721,14 +823,53 @@
         return;
       }
       trainStatus.style.color = 'var(--muted)';
-      trainStatus.textContent = 'Training in progress...';
+      trainStatus.textContent = backend.baseUrl ? 'Uploading samples to train your model…' : 'Training locally (simulated)...';
       trainButton.disabled = true;
-      setTimeout(() => {
+
+      const runLocal = () => {
         training.iterations += 1;
-        trainStatus.textContent = `Finished training pass ${training.iterations}. The assistant is updated!`;
+        trainStatus.textContent = `Finished training pass ${training.iterations} locally. Configure the backend for real training.`;
         trainButton.disabled = false;
         refreshTrainSummary();
-      }, 900);
+      };
+
+      if (!backend.baseUrl) {
+        setTimeout(runLocal, 900);
+        return;
+      }
+
+      const formData = new FormData();
+      training.photos.forEach((p, idx) => formData.append('photos', p.file || p.src, p.file?.name || `photo-${idx}.png`));
+      training.voices.forEach((v, idx) => formData.append('voices', v.file || v.src, v.file?.name || `voice-${idx}.wav`));
+      training.videos.forEach((v, idx) => formData.append('videos', v.file || v.src, v.file?.name || `video-${idx}.mp4`));
+      formData.append('notes', JSON.stringify({ existingModel: backend.modelId }));
+
+      fetch(backend.baseUrl.replace(/\/$/, '') + '/train', {
+        method: 'POST',
+        headers: backend.apiKey ? { Authorization: `Bearer ${backend.apiKey}` } : {},
+        body: formData,
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`Train failed: ${res.status}`);
+          return res.json();
+        })
+        .then((data) => {
+          training.iterations += 1;
+          backend.modelId = data.modelId || backend.modelId || 'session-model';
+          backend.avatarUrl = data.avatarUrl || backend.avatarUrl;
+          backend.voiceId = data.voiceId || backend.voiceId;
+          if (backend.avatarUrl) setAvatarPreview(backend.avatarUrl);
+          trainStatus.textContent = data.message || `Training complete on backend. Model: ${backend.modelId}`;
+          trainStatus.style.color = 'var(--success)';
+        })
+        .catch((err) => {
+          trainStatus.textContent = `Backend training failed: ${err.message}. Falling back to local simulation.`;
+          runLocal();
+        })
+        .finally(() => {
+          trainButton.disabled = false;
+          refreshTrainSummary();
+        });
     });
 
     renderButton.addEventListener('click', () => {
@@ -738,24 +879,73 @@
         return;
       }
       renderStatus.style.color = 'var(--muted)';
-      renderStatus.textContent = 'Rendering 8s talking avatar clip (simulated)...';
+      renderStatus.textContent = backend.baseUrl ? 'Requesting backend render…' : 'Rendering preview locally (simulated)…';
       renderButton.disabled = true;
-      let progress = 0;
-      const timer = setInterval(() => {
-        progress += 20;
-        renderStatus.textContent = `Synthesizing face sync · ${progress}%`;
-        if (progress >= 100) {
-          clearInterval(timer);
-          const chosenMood = training.videos[training.videos.length - 1]?.mood || 'friendly';
-          const look = training.photos.length ? 'your uploaded photos' : 'the default look';
-          const tone = training.voiceProfile ? `voice "${training.voiceProfile.name}"` : 'default voice';
-          const label = `Render ${new Date().toLocaleTimeString()}`;
+
+      const finishLocal = () => {
+        const chosenMood = training.videos[training.videos.length - 1]?.mood || 'friendly';
+        const look = training.photos.length ? 'your uploaded photos' : 'the default look';
+        const tone = training.voiceProfile ? `voice "${training.voiceProfile.name}"` : 'default voice';
+        const label = `Render ${new Date().toLocaleTimeString()}`;
+        training.lastRender = label;
+        renderStatus.textContent = `Rendered clip using ${look}, ${tone}, mood ${chosenMood}. (${label})`;
+        renderStatus.style.color = 'var(--success)';
+        renderButton.disabled = false;
+        refreshTrainSummary();
+      };
+
+      if (!backend.baseUrl) {
+        setTimeout(finishLocal, 1200);
+        return;
+      }
+
+      fetch(backend.baseUrl.replace(/\/$/, '') + '/render', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(backend.apiKey ? { Authorization: `Bearer ${backend.apiKey}` } : {}),
+        },
+        body: JSON.stringify({
+          modelId: backend.modelId,
+          avatarUrl: backend.avatarUrl || training.photos.at(-1)?.src,
+          voiceId: backend.voiceId,
+        }),
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`Render failed: ${res.status}`);
+          return res.json();
+        })
+        .then((data) => {
+          const label = data.label || `Render ${new Date().toLocaleTimeString()}`;
           training.lastRender = label;
-          renderStatus.textContent = `Rendered clip using ${look}, ${tone}, mood ${chosenMood}. (${label})`;
+          if (data.videoUrl) {
+            if (!document.getElementById('avatarVideo')) {
+              const vid = document.createElement('video');
+              vid.id = 'avatarVideo';
+              vid.autoplay = true;
+              vid.loop = true;
+              vid.muted = true;
+              vid.playsInline = true;
+              vid.style.position = 'absolute';
+              vid.style.inset = '0';
+              vid.style.width = '100%';
+              vid.style.height = '100%';
+              vid.style.objectFit = 'cover';
+              avatarFrame.appendChild(vid);
+            }
+            const avatarVideo = document.getElementById('avatarVideo');
+            avatarVideo.src = data.videoUrl;
+            avatarVideo.play().catch(() => {});
+          }
+          renderStatus.textContent = data.message || `Backend render ready. ${label}`;
+          renderStatus.style.color = 'var(--success)';
           renderButton.disabled = false;
           refreshTrainSummary();
-        }
-      }, 320);
+        })
+        .catch((err) => {
+          renderStatus.textContent = `Backend render failed: ${err.message}. Showing local preview instead.`;
+          finishLocal();
+        });
     });
 
     ttsPill.addEventListener('click', () => {
@@ -766,12 +956,14 @@
     // Initialize defaults
     setAvatarPreview('https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=300&q=80');
     appendMessage('Hello! Upload a photo/voice sample and start chatting.', 'bot');
+    messages.push({ role: 'assistant', content: 'Hello! Upload a photo/voice sample and start chatting.' });
     wireRecognition();
     selectVoiceProfile();
     if (window.speechSynthesis) {
       window.speechSynthesis.onvoiceschanged = selectVoiceProfile;
     }
     updateSpeechIndicator();
+    loadBackendConfig();
     refreshTrainSummary();
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,554 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-<meta name="google-site-verification" content="3yUtW8qlcctMLm_lgX-0GLQL7draGdwHO0ZR3BxQ_2c" />
-  </head>
- <body>
-<h1>Hello World</h1>
-<p>I'm hosted with GitHub Pages.</p>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Avatar Chatbot Studio</title>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: rgba(255, 255, 255, 0.06);
+      --panel-strong: rgba(255, 255, 255, 0.1);
+      --text: #e2e8f0;
+      --accent: #7c3aed;
+      --accent-2: #06b6d4;
+      --success: #22c55e;
+      --danger: #ef4444;
+      --muted: #94a3b8;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: var(--text);
+      background: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.3), transparent 30%),
+        radial-gradient(circle at 80% 0%, rgba(6, 182, 212, 0.25), transparent 25%),
+        linear-gradient(145deg, #0b1224, #0f172a 60%, #0b1020);
+      padding: 32px 16px 48px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: 32px;
+    }
+
+    p.lead {
+      margin: 0 0 24px;
+      color: var(--muted);
+      max-width: 800px;
+    }
+
+    .app-shell {
+      display: grid;
+      gap: 20px;
+      grid-template-columns: 1.2fr 1fr;
+      align-items: start;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--panel-strong);
+      border-radius: 16px;
+      backdrop-filter: blur(8px);
+      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
+      padding: 20px;
+    }
+
+    .card h2 {
+      margin: 0 0 8px;
+      font-size: 20px;
+    }
+
+    .card small {
+      color: var(--muted);
+    }
+
+    .hero {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+      margin-bottom: 10px;
+    }
+
+    .avatar-frame {
+      width: 96px;
+      height: 96px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.3), rgba(124, 58, 237, 0.4)),
+        linear-gradient(135deg, rgba(6, 182, 212, 0.8), rgba(124, 58, 237, 0.7));
+      border: 3px solid rgba(255, 255, 255, 0.15);
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 14px 40px rgba(124, 58, 237, 0.35);
+    }
+
+    .avatar-frame img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .avatar-status {
+      position: absolute;
+      bottom: 8px;
+      right: 8px;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: var(--success);
+      border: 2px solid #0f172a;
+      box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.5);
+    }
+
+    .chat-card {
+      height: 80vh;
+      min-height: 640px;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .chat-log {
+      flex: 1;
+      margin: 12px 0;
+      padding: 16px;
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.03);
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .message {
+      padding: 10px 12px;
+      border-radius: 14px;
+      max-width: 82%;
+      line-height: 1.5;
+      white-space: pre-wrap;
+    }
+
+    .message.user {
+      margin-left: auto;
+      background: linear-gradient(135deg, rgba(124, 58, 237, 0.35), rgba(6, 182, 212, 0.35));
+      border: 1px solid rgba(124, 58, 237, 0.3);
+    }
+
+    .message.bot {
+      margin-right: auto;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid var(--panel-strong);
+    }
+
+    .input-row {
+      display: grid;
+      grid-template-columns: 1fr auto auto;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .input-row input[type="text"] {
+      width: 100%;
+      padding: 12px 14px;
+      border-radius: 12px;
+      border: 1px solid var(--panel-strong);
+      background: rgba(15, 23, 42, 0.7);
+      color: var(--text);
+      font-size: 15px;
+    }
+
+    button {
+      border: none;
+      border-radius: 12px;
+      padding: 12px 16px;
+      cursor: pointer;
+      font-weight: 600;
+      color: white;
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+      box-shadow: 0 10px 30px rgba(124, 58, 237, 0.3);
+      transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+    }
+
+    button.secondary {
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--text);
+      border: 1px solid var(--panel-strong);
+      box-shadow: none;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      filter: brightness(1.05);
+    }
+
+    .stack {
+      display: grid;
+      gap: 12px;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 10px;
+      background: rgba(255, 255, 255, 0.06);
+      border-radius: 999px;
+      border: 1px solid var(--panel-strong);
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .status {
+      margin-top: 6px;
+      color: var(--muted);
+      font-size: 14px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .status strong {
+      color: var(--text);
+    }
+
+    .upload-box {
+      padding: 14px;
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px dashed rgba(255, 255, 255, 0.25);
+    }
+
+    .preview-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+      gap: 10px;
+    }
+
+    .preview-grid img, .preview-grid audio {
+      width: 100%;
+      border-radius: 10px;
+      border: 1px solid var(--panel-strong);
+      background: rgba(0, 0, 0, 0.2);
+    }
+
+    .toggle-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      justify-content: flex-end;
+      color: var(--muted);
+    }
+
+    .pill {
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(124, 58, 237, 0.15);
+      color: #ddd6fe;
+      border: 1px solid rgba(124, 58, 237, 0.3);
+      font-size: 12px;
+    }
+
+    .indicator {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--muted);
+    }
+
+    .indicator.on {
+      background: var(--success);
+      box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.15);
+    }
+
+    @media (max-width: 1024px) {
+      .app-shell {
+        grid-template-columns: 1fr;
+      }
+
+      .chat-card {
+        height: auto;
+        min-height: auto;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="hero">
+      <div class="avatar-frame" id="avatarFrame">
+        <img id="avatarImg" alt="Chatbot avatar" />
+        <div class="avatar-status" title="Ready to chat"></div>
+      </div>
+      <div>
+        <h1>Avatar Chatbot Studio</h1>
+        <p class="lead">Chat with a friendly assistant that responds with speech, listens to your voice, and can be tuned with your own sample photos and voice uploads.</p>
+        <div class="badge">Speech I/O · Avatar Preview · Upload-to-Train</div>
+      </div>
+    </div>
+  </header>
+
+  <div class="app-shell">
+    <section class="card chat-card">
+      <div class="toggle-row">
+        <span class="indicator" id="speechIndicator"></span>
+        <span id="speechIndicatorLabel">Speech off</span>
+        <div class="pill" id="ttsPill">Speech output: on</div>
+      </div>
+      <div class="chat-log" id="chatLog"></div>
+      <div class="input-row">
+        <input id="chatInput" type="text" placeholder="Type a message or use the mic" autocomplete="off" />
+        <button class="secondary" id="micButton" aria-label="Start voice input">🎤</button>
+        <button id="sendButton">Send</button>
+      </div>
+      <div class="status" id="micStatus">Voice input not started.</div>
+      <div class="status" id="trainSummary">No training samples yet.</div>
+    </section>
+
+    <section class="card stack">
+      <div>
+        <h2>Avatar & Voice Trainer</h2>
+        <small>Upload reference photos and voice clips to personalize the chatbot's appearance and tone.</small>
+      </div>
+
+      <div class="upload-box">
+        <strong>Photo samples</strong>
+        <p class="status">PNG or JPG. The latest photo becomes the chat avatar preview.</p>
+        <input id="photoInput" type="file" accept="image/*" multiple />
+        <div class="preview-grid" id="photoPreview"></div>
+      </div>
+
+      <div class="upload-box">
+        <strong>Voice samples</strong>
+        <p class="status">Upload short WAV or MP3 clips to influence the assistant's tone.</p>
+        <input id="voiceInput" type="file" accept="audio/*" multiple />
+        <div class="preview-grid" id="voicePreview"></div>
+      </div>
+
+      <div class="stack">
+        <button id="trainButton">Run quick training pass</button>
+        <div class="status" id="trainStatus">Idle · waiting for uploads.</div>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    const chatLog = document.getElementById('chatLog');
+    const chatInput = document.getElementById('chatInput');
+    const sendButton = document.getElementById('sendButton');
+    const micButton = document.getElementById('micButton');
+    const micStatus = document.getElementById('micStatus');
+    const speechIndicator = document.getElementById('speechIndicator');
+    const speechIndicatorLabel = document.getElementById('speechIndicatorLabel');
+    const ttsPill = document.getElementById('ttsPill');
+    const photoInput = document.getElementById('photoInput');
+    const voiceInput = document.getElementById('voiceInput');
+    const photoPreview = document.getElementById('photoPreview');
+    const voicePreview = document.getElementById('voicePreview');
+    const avatarImg = document.getElementById('avatarImg');
+    const trainButton = document.getElementById('trainButton');
+    const trainStatus = document.getElementById('trainStatus');
+    const trainSummary = document.getElementById('trainSummary');
+
+    let recognition;
+    let listening = false;
+    let speechOutput = true;
+    const training = {
+      photos: [],
+      voices: [],
+      iterations: 0,
+    };
+
+    function appendMessage(text, role) {
+      const message = document.createElement('div');
+      message.className = `message ${role}`;
+      message.textContent = text;
+      chatLog.appendChild(message);
+      chatLog.scrollTop = chatLog.scrollHeight;
+    }
+
+    function speak(text) {
+      if (!speechOutput || !('speechSynthesis' in window)) return;
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.pitch = 1;
+      utterance.rate = 1;
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utterance);
+    }
+
+    function respond(userText) {
+      const photoNote = training.photos.length ? `${training.photos.length} photo${training.photos.length > 1 ? 's' : ''}` : 'no photos yet';
+      const voiceNote = training.voices.length ? `${training.voices.length} voice clip${training.voices.length > 1 ? 's' : ''}` : 'no voice samples yet';
+      const response = `I heard: "${userText}". I'm speaking with your ${voiceNote} and imagining your ${photoNote}.`;
+      appendMessage(response, 'bot');
+      speak(response);
+    }
+
+    function handleSend() {
+      const text = chatInput.value.trim();
+      if (!text) return;
+      appendMessage(text, 'user');
+      chatInput.value = '';
+      respond(text);
+    }
+
+    function updateSpeechIndicator() {
+      speechIndicator.classList.toggle('on', listening);
+      speechIndicatorLabel.textContent = listening ? 'Listening…' : 'Speech off';
+    }
+
+    function startListening() {
+      if (!recognition) {
+        micStatus.textContent = 'Speech recognition is not supported in this browser.';
+        return;
+      }
+      recognition.start();
+      listening = true;
+      updateSpeechIndicator();
+      micStatus.textContent = 'Listening... speak now.';
+      micButton.textContent = '⏹️';
+    }
+
+    function stopListening() {
+      if (!recognition) return;
+      recognition.stop();
+      listening = false;
+      updateSpeechIndicator();
+      micStatus.textContent = 'Voice input stopped.';
+      micButton.textContent = '🎤';
+    }
+
+    function setAvatarPreview(src) {
+      avatarImg.src = src;
+    }
+
+    function refreshTrainSummary() {
+      const photoText = `${training.photos.length} photo sample${training.photos.length === 1 ? '' : 's'}`;
+      const voiceText = `${training.voices.length} voice sample${training.voices.length === 1 ? '' : 's'}`;
+      trainSummary.textContent = `Prepared with ${photoText} and ${voiceText}. Training runs: ${training.iterations}.`;
+    }
+
+    function handlePhotoUpload(files) {
+      photoPreview.innerHTML = '';
+      Array.from(files).forEach((file) => {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const img = document.createElement('img');
+          img.src = e.target.result;
+          photoPreview.appendChild(img);
+          training.photos.push(e.target.result);
+          setAvatarPreview(e.target.result);
+          refreshTrainSummary();
+        };
+        reader.readAsDataURL(file);
+      });
+    }
+
+    function handleVoiceUpload(files) {
+      voicePreview.innerHTML = '';
+      Array.from(files).forEach((file) => {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const audio = document.createElement('audio');
+          audio.controls = true;
+          audio.src = e.target.result;
+          voicePreview.appendChild(audio);
+          training.voices.push({ name: file.name, src: e.target.result });
+          refreshTrainSummary();
+        };
+        reader.readAsDataURL(file);
+      });
+    }
+
+    function wireRecognition() {
+      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognition) {
+        recognition = null;
+        micStatus.textContent = 'Speech recognition unavailable in this browser.';
+        return;
+      }
+      recognition = new SpeechRecognition();
+      recognition.continuous = false;
+      recognition.interimResults = false;
+      recognition.lang = 'en-US';
+
+      recognition.onresult = (event) => {
+        const transcript = event.results[0][0].transcript;
+        chatInput.value = transcript;
+        micStatus.textContent = `Captured: "${transcript}"`;
+        handleSend();
+      };
+
+      recognition.onend = () => {
+        listening = false;
+        updateSpeechIndicator();
+        micButton.textContent = '🎤';
+        micStatus.textContent = 'Voice input complete.';
+      };
+
+      recognition.onerror = (event) => {
+        micStatus.textContent = `Speech error: ${event.error}`;
+        listening = false;
+        updateSpeechIndicator();
+        micButton.textContent = '🎤';
+      };
+    }
+
+    sendButton.addEventListener('click', handleSend);
+    chatInput.addEventListener('keypress', (e) => {
+      if (e.key === 'Enter') handleSend();
+    });
+
+    micButton.addEventListener('click', () => {
+      if (listening) {
+        stopListening();
+      } else {
+        startListening();
+      }
+    });
+
+    photoInput.addEventListener('change', (e) => {
+      training.photos = [];
+      handlePhotoUpload(e.target.files);
+    });
+
+    voiceInput.addEventListener('change', (e) => {
+      training.voices = [];
+      handleVoiceUpload(e.target.files);
+    });
+
+    trainButton.addEventListener('click', () => {
+      if (!training.photos.length && !training.voices.length) {
+        trainStatus.textContent = 'Add at least one photo or voice sample to train.';
+        trainStatus.style.color = 'var(--danger)';
+        return;
+      }
+      trainStatus.style.color = 'var(--muted)';
+      trainStatus.textContent = 'Training in progress...';
+      trainButton.disabled = true;
+      setTimeout(() => {
+        training.iterations += 1;
+        trainStatus.textContent = `Finished training pass ${training.iterations}. The assistant is updated!`;
+        trainButton.disabled = false;
+        refreshTrainSummary();
+      }, 900);
+    });
+
+    ttsPill.addEventListener('click', () => {
+      speechOutput = !speechOutput;
+      ttsPill.textContent = `Speech output: ${speechOutput ? 'on' : 'off'}`;
+    });
+
+    // Initialize defaults
+    setAvatarPreview('https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=300&q=80');
+    appendMessage('Hello! Upload a photo/voice sample and start chatting.', 'bot');
+    wireRecognition();
+    updateSpeechIndicator();
+    refreshTrainSummary();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -76,15 +76,38 @@
     }
 
     .avatar-frame {
-      width: 96px;
-      height: 96px;
+      width: 120px;
+      height: 120px;
       border-radius: 50%;
-      background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.3), rgba(124, 58, 237, 0.4)),
+      background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.35), rgba(124, 58, 237, 0.45)),
         linear-gradient(135deg, rgba(6, 182, 212, 0.8), rgba(124, 58, 237, 0.7));
       border: 3px solid rgba(255, 255, 255, 0.15);
       position: relative;
       overflow: hidden;
       box-shadow: 0 14px 40px rgba(124, 58, 237, 0.35);
+      display: grid;
+      place-items: center;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.3s ease;
+    }
+
+    .avatar-frame:hover {
+      transform: translateY(-2px) scale(1.02);
+      box-shadow: 0 18px 60px rgba(124, 58, 237, 0.45);
+    }
+
+    .avatar-ring {
+      position: absolute;
+      inset: -6px;
+      border-radius: 50%;
+      border: 2px dashed rgba(255, 255, 255, 0.35);
+      animation: spin 14s linear infinite;
+      pointer-events: none;
+    }
+
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
     }
 
     .avatar-frame img {
@@ -92,6 +115,58 @@
       height: 100%;
       object-fit: cover;
       display: block;
+      position: relative;
+      z-index: 1;
+      animation: breathe 6s ease-in-out infinite;
+    }
+
+    @keyframes breathe {
+      0%, 100% { transform: scale(1); }
+      50% { transform: scale(1.02); }
+    }
+
+    .avatar-mouth {
+      position: absolute;
+      bottom: 18px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 46px;
+      height: 18px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 50% 40%, rgba(0, 0, 0, 0.45), rgba(124, 58, 237, 0.6));
+      opacity: 0;
+      z-index: 2;
+      transition: opacity 0.15s ease;
+      filter: blur(0.2px);
+    }
+
+    .avatar-frame.speaking .avatar-mouth {
+      opacity: 0.8;
+      animation: talk 0.2s ease-in-out infinite alternate;
+    }
+
+    @keyframes talk {
+      from { transform: translateX(-50%) scaleY(0.6); }
+      to { transform: translateX(-50%) scaleY(1.25); }
+    }
+
+    .avatar-voicewave {
+      position: absolute;
+      inset: 6px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(124, 58, 237, 0.08), rgba(6, 182, 212, 0.05));
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .avatar-frame.speaking .avatar-voicewave {
+      opacity: 1;
+      animation: pulse 1.2s ease-out infinite;
+    }
+
+    @keyframes pulse {
+      0% { transform: scale(1); opacity: 0.9; }
+      100% { transform: scale(1.2); opacity: 0; }
     }
 
     .avatar-status {
@@ -104,6 +179,7 @@
       background: var(--success);
       border: 2px solid #0f172a;
       box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.5);
+      z-index: 3;
     }
 
     .chat-card {
@@ -281,7 +357,10 @@
   <header>
     <div class="hero">
       <div class="avatar-frame" id="avatarFrame">
+        <div class="avatar-ring" aria-hidden="true"></div>
         <img id="avatarImg" alt="Chatbot avatar" />
+        <div class="avatar-mouth" aria-hidden="true"></div>
+        <div class="avatar-voicewave" aria-hidden="true"></div>
         <div class="avatar-status" title="Ready to chat"></div>
       </div>
       <div>
@@ -350,6 +429,7 @@
     const photoPreview = document.getElementById('photoPreview');
     const voicePreview = document.getElementById('voicePreview');
     const avatarImg = document.getElementById('avatarImg');
+    const avatarFrame = document.getElementById('avatarFrame');
     const trainButton = document.getElementById('trainButton');
     const trainStatus = document.getElementById('trainStatus');
     const trainSummary = document.getElementById('trainSummary');
@@ -361,7 +441,11 @@
       photos: [],
       voices: [],
       iterations: 0,
+      voiceProfile: null,
     };
+
+    let currentVoice;
+    let speaking = false;
 
     function appendMessage(text, role) {
       const message = document.createElement('div');
@@ -371,19 +455,38 @@
       chatLog.scrollTop = chatLog.scrollHeight;
     }
 
+    function setSpeaking(state) {
+      speaking = state;
+      avatarFrame.classList.toggle('speaking', state);
+      speechIndicator.classList.toggle('on', state || listening);
+      speechIndicatorLabel.textContent = state ? 'Speaking…' : listening ? 'Listening…' : 'Speech off';
+    }
+
     function speak(text) {
       if (!speechOutput || !('speechSynthesis' in window)) return;
       const utterance = new SpeechSynthesisUtterance(text);
-      utterance.pitch = 1;
-      utterance.rate = 1;
+      if (currentVoice) utterance.voice = currentVoice;
+      if (training.voiceProfile) {
+        utterance.pitch = training.voiceProfile.pitch;
+        utterance.rate = training.voiceProfile.rate;
+      }
+      utterance.onstart = () => setSpeaking(true);
+      utterance.onend = () => setSpeaking(false);
+      utterance.onerror = () => setSpeaking(false);
       window.speechSynthesis.cancel();
       window.speechSynthesis.speak(utterance);
     }
 
     function respond(userText) {
       const photoNote = training.photos.length ? `${training.photos.length} photo${training.photos.length > 1 ? 's' : ''}` : 'no photos yet';
-      const voiceNote = training.voices.length ? `${training.voices.length} voice clip${training.voices.length > 1 ? 's' : ''}` : 'no voice samples yet';
-      const response = `I heard: "${userText}". I'm speaking with your ${voiceNote} and imagining your ${photoNote}.`;
+      const voiceNote = training.voiceProfile ? `voice tuned to ${training.voiceProfile.name}` : 'default voice';
+      const presenceIntro = training.photos.length
+        ? 'I am mirroring the face you trained me with so you feel a real presence beside you.'
+        : 'Upload a photo to let me mirror your look while we talk.';
+      const persona = training.voiceProfile
+        ? `I am speaking with the tone of “${training.voiceProfile.name}” so it sounds like someone you know.`
+        : 'I will switch to your custom tone once you upload a voice sample.';
+      const response = `${presenceIntro} ${persona} I heard: "${userText}". I am using ${voiceNote} and imagining your ${photoNote}.`;
       appendMessage(response, 'bot');
       speak(response);
     }
@@ -397,8 +500,8 @@
     }
 
     function updateSpeechIndicator() {
-      speechIndicator.classList.toggle('on', listening);
-      speechIndicatorLabel.textContent = listening ? 'Listening…' : 'Speech off';
+      speechIndicator.classList.toggle('on', listening || speaking);
+      speechIndicatorLabel.textContent = speaking ? 'Speaking…' : listening ? 'Listening…' : 'Speech off';
     }
 
     function startListening() {
@@ -428,7 +531,7 @@
 
     function refreshTrainSummary() {
       const photoText = `${training.photos.length} photo sample${training.photos.length === 1 ? '' : 's'}`;
-      const voiceText = `${training.voices.length} voice sample${training.voices.length === 1 ? '' : 's'}`;
+      const voiceText = training.voiceProfile ? `voice tuned to ${training.voiceProfile.name}` : `${training.voices.length} voice sample${training.voices.length === 1 ? '' : 's'}`;
       trainSummary.textContent = `Prepared with ${photoText} and ${voiceText}. Training runs: ${training.iterations}.`;
     }
 
@@ -448,20 +551,33 @@
       });
     }
 
+    function selectVoiceProfile() {
+      const voices = window.speechSynthesis ? window.speechSynthesis.getVoices() : [];
+      currentVoice = voices.find((v) => v.lang?.startsWith('en')) || voices[0] || null;
+    }
+
     function handleVoiceUpload(files) {
       voicePreview.innerHTML = '';
-      Array.from(files).forEach((file) => {
+      Array.from(files).forEach((file, index) => {
         const reader = new FileReader();
         reader.onload = (e) => {
           const audio = document.createElement('audio');
           audio.controls = true;
           audio.src = e.target.result;
           voicePreview.appendChild(audio);
-          training.voices.push({ name: file.name, src: e.target.result });
+          const signature = {
+            name: file.name.replace(/\.[^/.]+$/, ''),
+            src: e.target.result,
+            pitch: 1 + index * 0.03,
+            rate: 1 - index * 0.02,
+          };
+          training.voices.push(signature);
+          training.voiceProfile = signature;
           refreshTrainSummary();
         };
         reader.readAsDataURL(file);
       });
+      selectVoiceProfile();
     }
 
     function wireRecognition() {
@@ -497,6 +613,12 @@
         micButton.textContent = '🎤';
       };
     }
+
+    avatarFrame.addEventListener('click', () => {
+      const prompt = 'Hey! I am right here with you. Ask me anything or tap the mic so we can talk naturally.';
+      appendMessage(prompt, 'bot');
+      speak(prompt);
+    });
 
     sendButton.addEventListener('click', handleSend);
     chatInput.addEventListener('keypress', (e) => {
@@ -547,6 +669,10 @@
     setAvatarPreview('https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=300&q=80');
     appendMessage('Hello! Upload a photo/voice sample and start chatting.', 'bot');
     wireRecognition();
+    selectVoiceProfile();
+    if (window.speechSynthesis) {
+      window.speechSynthesis.onvoiceschanged = selectVoiceProfile;
+    }
     updateSpeechIndicator();
     refreshTrainSummary();
   </script>


### PR DESCRIPTION
## Summary
- replace homepage with avatar chatbot interface featuring chat log, mic controls, and speech output toggle
- add upload flows for photo and voice samples that drive avatar preview, media playback, and quick training simulation
- include modern styling and default assistant greeting for immediate use

## Testing
- not run (not required)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929068efa6c833194cc13528613e83d)