### PR TITLE
Add Chrome Session Manager extension UI with tree view and JSON import/export

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,71 @@
+const STORAGE_KEY = "sessions";
+const MAX_SESSIONS = 50;
+
+const getSessions = async () => {
+  const result = await chrome.storage.local.get(STORAGE_KEY);
+  return result[STORAGE_KEY] || [];
+};
+
+const saveSessions = async (sessions) => {
+  await chrome.storage.local.set({ [STORAGE_KEY]: sessions });
+};
+
+const buildSession = async (label = "Auto Saved Session") => {
+  const windows = await chrome.windows.getAll({
+    populate: true,
+    windowTypes: ["normal"],
+  });
+
+  return {
+    id: crypto.randomUUID(),
+    name: label,
+    createdAt: new Date().toISOString(),
+    windows: windows.map((window) => ({
+      title: window.title || "Chrome Window",
+      tabs: (window.tabs || []).map((tab) => ({
+        title: tab.title || tab.pendingUrl || "Untitled Tab",
+        url: tab.url || tab.pendingUrl || "",
+        favIconUrl: tab.favIconUrl || "",
+      })),
+    })),
+  };
+};
+
+const saveCurrentSession = async (label) => {
+  const sessions = await getSessions();
+  const session = await buildSession(label);
+  const updated = [session, ...sessions].slice(0, MAX_SESSIONS);
+  await saveSessions(updated);
+};
+
+chrome.runtime.onStartup.addListener(() => {
+  saveCurrentSession("Startup Session").catch(() => {});
+});
+
+chrome.runtime.onSuspend.addListener(() => {
+  saveCurrentSession("Auto Saved Session").catch(() => {});
+});
+
+chrome.action.onClicked.addListener(async () => {
+  const targetUrl = chrome.runtime.getURL("session.html");
+  const windows = await chrome.windows.getAll({ populate: true });
+  const existing = windows.find((window) =>
+    (window.tabs || []).some((tab) => tab.url === targetUrl)
+  );
+
+  if (existing) {
+    await chrome.windows.update(existing.id, { focused: true });
+    const tab = (existing.tabs || []).find((t) => t.url === targetUrl);
+    if (tab?.id) {
+      await chrome.tabs.update(tab.id, { active: true });
+    }
+    return;
+  }
+
+  await chrome.windows.create({
+    url: targetUrl,
+    type: "popup",
+    width: 1200,
+    height: 800,
+  });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Session Manager Treeview",
+  "version": "1.0.0",
+  "description": "Automatically save and manage Chrome sessions with a tree view.",
+  "permissions": ["storage", "tabs", "windows"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "Session Manager"
+  }
+}

--- a/session.css
+++ b/session.css
@@ -123,9 +123,7 @@ main {
   gap: 8px;
   font-weight: 600;
   min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  position: relative;
 }
 
 .title img {
@@ -135,10 +133,13 @@ main {
 
 .title .node-title,
 .title .tab-title {
+  display: inline-block;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: inherit;
+  text-decoration: none;
 }
 
 .node-actions {

--- a/session.css
+++ b/session.css
@@ -15,14 +15,14 @@ body {
   gap: 16px;
   align-items: center;
   justify-content: space-between;
-  padding: 24px 32px;
+  padding: 16px 24px;
   background: #ffffff;
   border-bottom: 1px solid #e5e7eb;
 }
 
 .app-header h1 {
   margin: 0 0 4px 0;
-  font-size: 24px;
+  font-size: 20px;
 }
 
 .app-header p {
@@ -33,16 +33,17 @@ body {
 .header-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 8px;
 }
 
 button {
   border: 1px solid #cbd2d9;
   background: #ffffff;
-  padding: 8px 14px;
-  border-radius: 8px;
+  padding: 6px 10px;
+  border-radius: 6px;
   cursor: pointer;
   font-weight: 600;
+  font-size: 12px;
 }
 
 button.primary {
@@ -54,10 +55,11 @@ button.primary {
 label.file-input {
   border: 1px solid #cbd2d9;
   background: #ffffff;
-  padding: 8px 14px;
-  border-radius: 8px;
+  padding: 6px 10px;
+  border-radius: 6px;
   cursor: pointer;
   font-weight: 600;
+  font-size: 12px;
 }
 
 label.file-input input {
@@ -70,15 +72,16 @@ button:disabled {
 }
 
 main {
-  padding: 24px 32px 40px;
+  padding: 16px 24px 32px;
 }
 
 .toolbar {
   display: flex;
   align-items: center;
-  gap: 16px;
-  margin-bottom: 16px;
+  gap: 12px;
+  margin-bottom: 12px;
   color: #52606d;
+  flex-wrap: wrap;
 }
 
 .checkbox {
@@ -91,20 +94,20 @@ main {
 .tree {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .node {
   background: #ffffff;
   border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 12px 16px;
+  border-radius: 10px;
+  padding: 8px 12px;
 }
 
 .node-header {
   display: grid;
   grid-template-columns: auto auto 1fr auto;
-  gap: 12px;
+  gap: 8px;
   align-items: center;
 }
 
@@ -113,8 +116,8 @@ main {
   background: transparent;
   font-size: 18px;
   cursor: pointer;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
 }
 
 .title {
@@ -144,20 +147,20 @@ main {
 
 .node-actions {
   display: flex;
-  gap: 8px;
+  gap: 6px;
 }
 
 .node-actions button {
-  padding: 6px 10px;
-  font-size: 12px;
+  padding: 4px 8px;
+  font-size: 11px;
 }
 
 .children {
-  margin-top: 12px;
-  padding-left: 20px;
+  margin-top: 8px;
+  padding-left: 16px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .children.collapsed {
@@ -167,10 +170,10 @@ main {
 .tab-row {
   display: grid;
   grid-template-columns: auto 1fr auto;
-  gap: 12px;
+  gap: 8px;
   align-items: center;
-  padding: 8px 12px;
-  border-radius: 8px;
+  padding: 6px 10px;
+  border-radius: 6px;
   background: #f8fafc;
   border: 1px solid #e2e8f0;
 }
@@ -209,7 +212,7 @@ main {
 
 .tab-actions {
   display: flex;
-  gap: 6px;
+  gap: 4px;
 }
 
 .drag-hint {
@@ -218,11 +221,28 @@ main {
 }
 
 .empty-state {
-  padding: 40px;
+  padding: 28px;
   text-align: center;
   background: #ffffff;
-  border-radius: 12px;
+  border-radius: 10px;
   border: 1px dashed #cbd2d9;
+}
+
+.expand-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.control-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #7b8794;
+}
+
+button.ghost {
+  background: #f1f5f9;
+  border-color: #e2e8f0;
 }
 
 .drop-target {

--- a/session.css
+++ b/session.css
@@ -122,11 +122,23 @@ main {
   align-items: center;
   gap: 8px;
   font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .title img {
   width: 16px;
   height: 16px;
+}
+
+.title .node-title,
+.title .tab-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .node-actions {
@@ -162,17 +174,36 @@ main {
   border: 1px solid #e2e8f0;
 }
 
+.tab-row .title {
+  position: relative;
+}
+
 .tab-row:hover .tab-link {
   opacity: 1;
   pointer-events: auto;
+  transform: translateY(0);
 }
 
 .tab-link {
   opacity: 0;
   pointer-events: none;
-  color: #2563eb;
+  color: #ffffff;
   text-decoration: none;
   font-size: 12px;
+  position: absolute;
+  left: 24px;
+  top: 100%;
+  margin-top: 6px;
+  background: rgba(15, 23, 42, 0.95);
+  padding: 6px 10px;
+  border-radius: 6px;
+  max-width: 420px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transform: translateY(-4px);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 5;
 }
 
 .tab-actions {

--- a/session.css
+++ b/session.css
@@ -1,0 +1,199 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  background: #f5f7fb;
+  color: #1f2933;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px 32px;
+  background: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.app-header h1 {
+  margin: 0 0 4px 0;
+  font-size: 24px;
+}
+
+.app-header p {
+  margin: 0;
+  color: #52606d;
+}
+
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+button {
+  border: 1px solid #cbd2d9;
+  background: #ffffff;
+  padding: 8px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+button.primary {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+label.file-input {
+  border: 1px solid #cbd2d9;
+  background: #ffffff;
+  padding: 8px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+label.file-input input {
+  display: none;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+main {
+  padding: 24px 32px 40px;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+  color: #52606d;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.tree {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.node {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.node-header {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.toggle {
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.title img {
+  width: 16px;
+  height: 16px;
+}
+
+.node-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.node-actions button {
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.children {
+  margin-top: 12px;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.children.collapsed {
+  display: none;
+}
+
+.tab-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.tab-row:hover .tab-link {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.tab-link {
+  opacity: 0;
+  pointer-events: none;
+  color: #2563eb;
+  text-decoration: none;
+  font-size: 12px;
+}
+
+.tab-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.drag-hint {
+  font-size: 12px;
+  color: #9aa5b1;
+}
+
+.empty-state {
+  padding: 40px;
+  text-align: center;
+  background: #ffffff;
+  border-radius: 12px;
+  border: 1px dashed #cbd2d9;
+}
+
+.drop-target {
+  outline: 2px dashed #2563eb;
+  outline-offset: 2px;
+}

--- a/session.html
+++ b/session.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Session Manager</title>
+    <link rel="stylesheet" href="session.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div>
+        <h1>Session Manager</h1>
+        <p>Automatically saved sessions with a tree view.</p>
+      </div>
+      <div class="header-actions">
+        <button id="save-session" class="primary">Save Now</button>
+        <button id="restore-selected">Restore Selected</button>
+        <button id="delete-selected">Delete Selected</button>
+        <button id="close-selected">Close Selected</button>
+        <button id="export-json">Export JSON</button>
+        <label class="file-input">
+          <input type="file" id="import-json" accept="application/json" />
+          Import JSON
+        </label>
+      </div>
+    </header>
+
+    <main>
+      <section class="toolbar">
+        <label class="checkbox">
+          <input type="checkbox" id="select-all" />
+          <span>Select all</span>
+        </label>
+        <div class="hint">
+          Drag tabs to reorder or move them between windows.
+        </div>
+      </section>
+
+      <section id="session-list" class="tree"></section>
+    </main>
+
+    <template id="empty-state">
+      <div class="empty-state">
+        <h2>No sessions saved yet.</h2>
+        <p>Click "Save Now" to capture your current windows and tabs.</p>
+      </div>
+    </template>
+
+    <script src="session.js"></script>
+  </body>
+</html>

--- a/session.html
+++ b/session.html
@@ -31,6 +31,18 @@
           <input type="checkbox" id="select-all" />
           <span>Select all</span>
         </label>
+        <div class="expand-controls">
+          <span class="control-label">Expand:</span>
+          <button type="button" class="ghost" data-expand="all">All</button>
+          <button type="button" class="ghost" data-expand="windows">Windows</button>
+          <button type="button" class="ghost" data-expand="tabs">Tabs</button>
+        </div>
+        <div class="expand-controls">
+          <span class="control-label">Collapse:</span>
+          <button type="button" class="ghost" data-collapse="all">All</button>
+          <button type="button" class="ghost" data-collapse="windows">Windows</button>
+          <button type="button" class="ghost" data-collapse="tabs">Tabs</button>
+        </div>
         <div class="hint">
           Drag tabs to reorder or move them between windows.
         </div>

--- a/session.js
+++ b/session.js
@@ -254,11 +254,6 @@ const createWindowNode = (session, window, windowIndex) => {
     updateParentCheckboxes(event.target);
   });
 
-  node.addEventListener("dragstart", handleDragStart);
-  node.addEventListener("dragover", handleDragOver);
-  node.addEventListener("drop", handleDrop);
-  node.addEventListener("dragleave", handleDragLeave);
-
   node.append(header, children);
   return node;
 };
@@ -282,17 +277,20 @@ const createTabNode = (session, tab, windowIndex, tabIndex) => {
   const title = document.createElement("div");
   title.className = "title";
   const favicon = document.createElement("img");
-  favicon.src = tab.favIconUrl || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Crect width='16' height='16' rx='4' fill='%23cbd2d9'/%3E%3C/svg%3E";
+  favicon.src =
+    tab.favIconUrl ||
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Crect width='16' height='16' rx='4' fill='%23cbd2d9'/%3E%3C/svg%3E";
   favicon.alt = "";
-  const text = document.createElement("span");
-  text.className = "tab-title";
-  text.textContent = tab.title || "Untitled Tab";
-  const link = document.createElement("a");
-  link.href = tab.url || "#";
+  const titleLink = document.createElement("a");
+  titleLink.className = "tab-title";
+  titleLink.href = tab.url || "#";
+  titleLink.textContent = tab.title || "Untitled Tab";
+  titleLink.target = "_blank";
+  titleLink.rel = "noopener noreferrer";
+  const link = document.createElement("span");
   link.textContent = tab.url || "No URL";
   link.className = "tab-link";
-  link.target = "_blank";
-  title.append(favicon, text, link);
+  title.append(favicon, titleLink, link);
 
   const actions = document.createElement("div");
   actions.className = "tab-actions";
@@ -307,11 +305,6 @@ const createTabNode = (session, tab, windowIndex, tabIndex) => {
   checkbox.addEventListener("change", (event) => {
     updateParentCheckboxes(event.target);
   });
-
-  node.addEventListener("dragstart", handleDragStart);
-  node.addEventListener("dragover", handleDragOver);
-  node.addEventListener("drop", handleDrop);
-  node.addEventListener("dragleave", handleDragLeave);
 
   return node;
 };
@@ -538,8 +531,13 @@ const closeSelected = async () => {
   }
 };
 
+const getNodeTarget = (event) => event.target.closest("[data-node]");
+
 const handleDragStart = (event) => {
-  const node = event.currentTarget;
+  const node = getNodeTarget(event);
+  if (!node) {
+    return;
+  }
   event.dataTransfer.setData(
     "text/plain",
     JSON.stringify({
@@ -553,21 +551,32 @@ const handleDragStart = (event) => {
 };
 
 const handleDragOver = (event) => {
+  const targetNode = getNodeTarget(event);
+  if (!targetNode) {
+    return;
+  }
   event.preventDefault();
-  event.currentTarget.classList.add("drop-target");
+  targetNode.classList.add("drop-target");
 };
 
 const handleDragLeave = (event) => {
-  event.currentTarget.classList.remove("drop-target");
+  const targetNode = getNodeTarget(event);
+  if (!targetNode) {
+    return;
+  }
+  targetNode.classList.remove("drop-target");
 };
 
 const handleDrop = async (event) => {
+  const targetNode = getNodeTarget(event);
+  if (!targetNode) {
+    return;
+  }
   event.preventDefault();
-  event.currentTarget.classList.remove("drop-target");
+  targetNode.classList.remove("drop-target");
   const data = JSON.parse(event.dataTransfer.getData("text/plain"));
-  const targetNode = event.currentTarget;
 
-  if (data.sessionId !== targetNode.dataset.sessionId) {
+  if (!data.sessionId || data.sessionId !== targetNode.dataset.sessionId) {
     return;
   }
 
@@ -606,11 +615,16 @@ const handleDrop = async (event) => {
 
 const attachEventHandlers = () => {
   sessionList.addEventListener("click", (event) => {
-    const target = event.target;
-    if (target.matches("button[data-action]")) {
+    const target = event.target.closest("button[data-action]");
+    if (target) {
       handleAction(target.dataset.action, target);
     }
   });
+
+  sessionList.addEventListener("dragstart", handleDragStart);
+  sessionList.addEventListener("dragover", handleDragOver);
+  sessionList.addEventListener("drop", handleDrop);
+  sessionList.addEventListener("dragleave", handleDragLeave);
 
   selectAll.addEventListener("change", (event) => {
     const checked = event.target.checked;
@@ -668,7 +682,6 @@ const init = async () => {
   if (!isExtensionEnv) {
     saveButton.disabled = true;
     restoreSelectedButton.disabled = true;
-    deleteSelectedButton.disabled = true;
     closeSelectedButton.disabled = true;
   }
 };

--- a/session.js
+++ b/session.js
@@ -1,0 +1,669 @@
+const STORAGE_KEY = "sessions";
+
+const sessionList = document.getElementById("session-list");
+const selectAll = document.getElementById("select-all");
+const saveButton = document.getElementById("save-session");
+const restoreSelectedButton = document.getElementById("restore-selected");
+const deleteSelectedButton = document.getElementById("delete-selected");
+const closeSelectedButton = document.getElementById("close-selected");
+const exportJsonButton = document.getElementById("export-json");
+const importJsonInput = document.getElementById("import-json");
+
+let sessions = [];
+const isExtensionEnv =
+  typeof chrome !== "undefined" && Boolean(chrome.storage?.local);
+
+const getSessions = async () => {
+  if (!isExtensionEnv) {
+    return [
+      {
+        id: "sample-session",
+        name: "Sample Session",
+        createdAt: new Date().toISOString(),
+        windows: [
+          {
+            title: "Design Research",
+            tabs: [
+              {
+                title: "Inspiration Board",
+                url: "https://example.com/inspiration",
+                favIconUrl: "",
+              },
+              {
+                title: "User Interviews",
+                url: "https://example.com/interviews",
+                favIconUrl: "",
+              },
+            ],
+          },
+          {
+            title: "Sprint Planning",
+            tabs: [
+              {
+                title: "Backlog",
+                url: "https://example.com/backlog",
+                favIconUrl: "",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+  }
+  const result = await chrome.storage.local.get(STORAGE_KEY);
+  return result[STORAGE_KEY] || [];
+};
+
+const saveSessions = async (updated) => {
+  if (isExtensionEnv) {
+    await chrome.storage.local.set({ [STORAGE_KEY]: updated });
+  }
+  sessions = updated;
+};
+
+const buildSession = async (label = "Manual Save") => {
+  if (!isExtensionEnv) {
+    return {
+      id: crypto.randomUUID(),
+      name: label,
+      createdAt: new Date().toISOString(),
+      windows: [],
+    };
+  }
+  const windows = await chrome.windows.getAll({
+    populate: true,
+    windowTypes: ["normal"],
+  });
+
+  return {
+    id: crypto.randomUUID(),
+    name: label,
+    createdAt: new Date().toISOString(),
+    windows: windows.map((window) => ({
+      title: window.title || "Chrome Window",
+      tabs: (window.tabs || []).map((tab) => ({
+        title: tab.title || tab.pendingUrl || "Untitled Tab",
+        url: tab.url || tab.pendingUrl || "",
+        favIconUrl: tab.favIconUrl || "",
+      })),
+    })),
+  };
+};
+
+const renderEmptyState = () => {
+  const template = document.getElementById("empty-state");
+  sessionList.innerHTML = "";
+  sessionList.appendChild(template.content.cloneNode(true));
+};
+
+const createButton = (label, action, extra = {}) => {
+  const button = document.createElement("button");
+  button.textContent = label;
+  button.dataset.action = action;
+  Object.assign(button.dataset, extra);
+  return button;
+};
+
+const createCheckbox = (extra = {}) => {
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  Object.assign(checkbox.dataset, extra);
+  return checkbox;
+};
+
+const updateParentCheckboxes = (checkbox) => {
+  let parent = checkbox.closest(".children")?.closest("[data-node]");
+  while (parent) {
+    const checkboxes = parent.querySelectorAll(
+      ".children > [data-node] input[type='checkbox']"
+    );
+    const checked = Array.from(checkboxes).filter((input) => input.checked);
+    const parentCheckbox = parent.querySelector("input[type='checkbox']");
+
+    if (parentCheckbox) {
+      parentCheckbox.checked = checked.length === checkboxes.length;
+      parentCheckbox.indeterminate =
+        checked.length > 0 && checked.length < checkboxes.length;
+    }
+
+    parent = parent.closest(".children")?.closest("[data-node]");
+  }
+};
+
+const toggleChildren = (checkbox, checked) => {
+  const node = checkbox.closest("[data-node]");
+  if (!node) {
+    return;
+  }
+  const descendants = node.querySelectorAll(".children input[type='checkbox']");
+  descendants.forEach((child) => {
+    child.checked = checked;
+    child.indeterminate = false;
+  });
+};
+
+const createSessionNode = (session, index) => {
+  const node = document.createElement("div");
+  node.className = "node";
+  node.dataset.node = "session";
+  node.dataset.sessionId = session.id;
+  node.dataset.sessionIndex = index;
+
+  const header = document.createElement("div");
+  header.className = "node-header";
+
+  const toggle = document.createElement("button");
+  toggle.className = "toggle";
+  toggle.textContent = "▾";
+
+  const checkbox = createCheckbox({
+    nodeType: "session",
+    sessionId: session.id,
+  });
+
+  const title = document.createElement("div");
+  title.className = "title";
+  title.textContent = `${session.name} • ${new Date(
+    session.createdAt
+  ).toLocaleString()}`;
+
+  const actions = document.createElement("div");
+  actions.className = "node-actions";
+  actions.append(
+    createButton("Restore", "restore", { nodeType: "session" }),
+    createButton("Delete", "delete", { nodeType: "session" }),
+    createButton("Close", "close", { nodeType: "session" })
+  );
+
+  header.append(toggle, checkbox, title, actions);
+
+  const children = document.createElement("div");
+  children.className = "children";
+  session.windows.forEach((window, windowIndex) => {
+    children.appendChild(createWindowNode(session, window, windowIndex));
+  });
+
+  toggle.addEventListener("click", () => {
+    children.classList.toggle("collapsed");
+    toggle.textContent = children.classList.contains("collapsed") ? "▸" : "▾";
+  });
+
+  checkbox.addEventListener("change", (event) => {
+    toggleChildren(event.target, event.target.checked);
+    updateParentCheckboxes(event.target);
+  });
+
+  node.append(header, children);
+  return node;
+};
+
+const createWindowNode = (session, window, windowIndex) => {
+  const node = document.createElement("div");
+  node.className = "node";
+  node.dataset.node = "window";
+  node.dataset.sessionId = session.id;
+  node.dataset.windowIndex = windowIndex;
+  node.draggable = true;
+
+  const header = document.createElement("div");
+  header.className = "node-header";
+
+  const toggle = document.createElement("button");
+  toggle.className = "toggle";
+  toggle.textContent = "▾";
+
+  const checkbox = createCheckbox({
+    nodeType: "window",
+    sessionId: session.id,
+    windowIndex,
+  });
+
+  const title = document.createElement("div");
+  title.className = "title";
+  title.textContent = `${window.title} (${window.tabs.length} tabs)`;
+
+  const actions = document.createElement("div");
+  actions.className = "node-actions";
+  actions.append(
+    createButton("Restore", "restore", { nodeType: "window" }),
+    createButton("Delete", "delete", { nodeType: "window" }),
+    createButton("Close", "close", { nodeType: "window" })
+  );
+
+  header.append(toggle, checkbox, title, actions);
+
+  const children = document.createElement("div");
+  children.className = "children";
+  window.tabs.forEach((tab, tabIndex) => {
+    children.appendChild(createTabNode(session, tab, windowIndex, tabIndex));
+  });
+
+  toggle.addEventListener("click", () => {
+    children.classList.toggle("collapsed");
+    toggle.textContent = children.classList.contains("collapsed") ? "▸" : "▾";
+  });
+
+  checkbox.addEventListener("change", (event) => {
+    toggleChildren(event.target, event.target.checked);
+    updateParentCheckboxes(event.target);
+  });
+
+  node.addEventListener("dragstart", handleDragStart);
+  node.addEventListener("dragover", handleDragOver);
+  node.addEventListener("drop", handleDrop);
+  node.addEventListener("dragleave", handleDragLeave);
+
+  node.append(header, children);
+  return node;
+};
+
+const createTabNode = (session, tab, windowIndex, tabIndex) => {
+  const node = document.createElement("div");
+  node.className = "tab-row";
+  node.dataset.node = "tab";
+  node.dataset.sessionId = session.id;
+  node.dataset.windowIndex = windowIndex;
+  node.dataset.tabIndex = tabIndex;
+  node.draggable = true;
+
+  const checkbox = createCheckbox({
+    nodeType: "tab",
+    sessionId: session.id,
+    windowIndex,
+    tabIndex,
+  });
+
+  const title = document.createElement("div");
+  title.className = "title";
+  const favicon = document.createElement("img");
+  favicon.src = tab.favIconUrl || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Crect width='16' height='16' rx='4' fill='%23cbd2d9'/%3E%3C/svg%3E";
+  favicon.alt = "";
+  const text = document.createElement("span");
+  text.textContent = tab.title || "Untitled Tab";
+  const link = document.createElement("a");
+  link.href = tab.url || "#";
+  link.textContent = tab.url || "No URL";
+  link.className = "tab-link";
+  link.target = "_blank";
+  title.append(favicon, text, link);
+
+  const actions = document.createElement("div");
+  actions.className = "tab-actions";
+  actions.append(
+    createButton("Restore", "restore", { nodeType: "tab" }),
+    createButton("Delete", "delete", { nodeType: "tab" }),
+    createButton("Close", "close", { nodeType: "tab" })
+  );
+
+  node.append(checkbox, title, actions);
+
+  checkbox.addEventListener("change", (event) => {
+    updateParentCheckboxes(event.target);
+  });
+
+  node.addEventListener("dragstart", handleDragStart);
+  node.addEventListener("dragover", handleDragOver);
+  node.addEventListener("drop", handleDrop);
+  node.addEventListener("dragleave", handleDragLeave);
+
+  return node;
+};
+
+const renderSessions = () => {
+  sessionList.innerHTML = "";
+
+  if (!sessions.length) {
+    renderEmptyState();
+    return;
+  }
+
+  sessions.forEach((session, index) => {
+    sessionList.appendChild(createSessionNode(session, index));
+  });
+};
+
+const handleAction = async (action, target) => {
+  const nodeType = target.dataset.nodeType;
+  const sessionId = target.closest("[data-node]")?.dataset.sessionId;
+  const sessionIndex = sessions.findIndex((s) => s.id === sessionId);
+  if (sessionIndex === -1) {
+    return;
+  }
+
+  if (nodeType === "session") {
+    if (action === "restore") {
+      await restoreSession(sessions[sessionIndex]);
+    } else if (action === "delete") {
+      sessions.splice(sessionIndex, 1);
+      await saveSessions(sessions);
+      renderSessions();
+    } else if (action === "close") {
+      await closeSessionTabs(sessions[sessionIndex]);
+    }
+    return;
+  }
+
+  const windowIndex = Number(target.closest("[data-node]").dataset.windowIndex);
+  const session = sessions[sessionIndex];
+  const windowData = session.windows[windowIndex];
+
+  if (nodeType === "window") {
+    if (action === "restore") {
+      await restoreWindow(windowData);
+    } else if (action === "delete") {
+      session.windows.splice(windowIndex, 1);
+      await saveSessions(sessions);
+      renderSessions();
+    } else if (action === "close") {
+      await closeWindowTabs(windowData);
+    }
+    return;
+  }
+
+  if (nodeType === "tab") {
+    const tabIndex = Number(target.closest("[data-node]").dataset.tabIndex);
+    const tabData = windowData.tabs[tabIndex];
+    if (action === "restore") {
+      await restoreTab(tabData);
+    } else if (action === "delete") {
+      windowData.tabs.splice(tabIndex, 1);
+      await saveSessions(sessions);
+      renderSessions();
+    } else if (action === "close") {
+      await closeTab(tabData);
+    }
+  }
+};
+
+const restoreSession = async (session) => {
+  if (!isExtensionEnv) {
+    return;
+  }
+  for (const window of session.windows) {
+    await restoreWindow(window);
+  }
+};
+
+const restoreWindow = async (windowData) => {
+  if (!isExtensionEnv) {
+    return;
+  }
+  const urls = windowData.tabs.map((tab) => tab.url || "chrome://newtab/");
+  await chrome.windows.create({
+    url: urls.length ? urls : ["chrome://newtab/"],
+  });
+};
+
+const restoreTab = async (tabData) => {
+  if (!isExtensionEnv) {
+    return;
+  }
+  const window = await chrome.windows.getLastFocused({ populate: false });
+  await chrome.tabs.create({
+    windowId: window.id,
+    url: tabData.url || "chrome://newtab/",
+  });
+};
+
+const closeSessionTabs = async (session) => {
+  if (!isExtensionEnv) {
+    return;
+  }
+  for (const window of session.windows) {
+    await closeWindowTabs(window);
+  }
+};
+
+const closeWindowTabs = async (windowData) => {
+  if (!isExtensionEnv) {
+    return;
+  }
+  const liveWindows = await chrome.windows.getAll({ populate: true });
+  for (const liveWindow of liveWindows) {
+    const liveUrls = (liveWindow.tabs || []).map((tab) => tab.url);
+    const targetUrls = windowData.tabs.map((tab) => tab.url);
+    const isMatch =
+      liveUrls.length === targetUrls.length &&
+      liveUrls.every((url, index) => url === targetUrls[index]);
+    if (isMatch) {
+      await chrome.windows.remove(liveWindow.id);
+      return;
+    }
+  }
+
+  for (const tab of windowData.tabs) {
+    await closeTab(tab);
+  }
+};
+
+const closeTab = async (tabData) => {
+  if (!isExtensionEnv) {
+    return;
+  }
+  if (!tabData.url) {
+    return;
+  }
+  const tabs = await chrome.tabs.query({ url: tabData.url });
+  if (tabs.length) {
+    await chrome.tabs.remove(tabs[0].id);
+  }
+};
+
+const getCheckedNodes = () =>
+  Array.from(
+    document.querySelectorAll("input[type='checkbox']:checked")
+  ).filter((input) => input.dataset.nodeType);
+
+const restoreSelected = async () => {
+  const checked = getCheckedNodes();
+  for (const input of checked) {
+    const nodeType = input.dataset.nodeType;
+    const session = sessions.find((item) => item.id === input.dataset.sessionId);
+    if (!session) {
+      continue;
+    }
+    if (nodeType === "session") {
+      await restoreSession(session);
+    } else if (nodeType === "window") {
+      const windowData = session.windows[Number(input.dataset.windowIndex)];
+      if (windowData) {
+        await restoreWindow(windowData);
+      }
+    } else if (nodeType === "tab") {
+      const windowData = session.windows[Number(input.dataset.windowIndex)];
+      const tab = windowData?.tabs[Number(input.dataset.tabIndex)];
+      if (tab) {
+        await restoreTab(tab);
+      }
+    }
+  }
+};
+
+const deleteSelected = async () => {
+  const checked = getCheckedNodes();
+  checked
+    .sort((a, b) => (b.dataset.nodeType || "").localeCompare(a.dataset.nodeType))
+    .forEach((input) => {
+      const sessionIndex = sessions.findIndex(
+        (item) => item.id === input.dataset.sessionId
+      );
+      if (sessionIndex === -1) {
+        return;
+      }
+      const session = sessions[sessionIndex];
+      if (input.dataset.nodeType === "session") {
+        sessions.splice(sessionIndex, 1);
+        return;
+      }
+      const windowIndex = Number(input.dataset.windowIndex);
+      if (input.dataset.nodeType === "window") {
+        session.windows.splice(windowIndex, 1);
+        return;
+      }
+      const tabIndex = Number(input.dataset.tabIndex);
+      session.windows[windowIndex]?.tabs.splice(tabIndex, 1);
+    });
+  await saveSessions(sessions);
+  renderSessions();
+};
+
+const closeSelected = async () => {
+  const checked = getCheckedNodes();
+  for (const input of checked) {
+    const session = sessions.find((item) => item.id === input.dataset.sessionId);
+    if (!session) {
+      continue;
+    }
+    if (input.dataset.nodeType === "session") {
+      await closeSessionTabs(session);
+    } else if (input.dataset.nodeType === "window") {
+      const windowData = session.windows[Number(input.dataset.windowIndex)];
+      if (windowData) {
+        await closeWindowTabs(windowData);
+      }
+    } else if (input.dataset.nodeType === "tab") {
+      const windowData = session.windows[Number(input.dataset.windowIndex)];
+      const tab = windowData?.tabs[Number(input.dataset.tabIndex)];
+      if (tab) {
+        await closeTab(tab);
+      }
+    }
+  }
+};
+
+const handleDragStart = (event) => {
+  const node = event.currentTarget;
+  event.dataTransfer.setData(
+    "text/plain",
+    JSON.stringify({
+      nodeType: node.dataset.node,
+      sessionId: node.dataset.sessionId,
+      windowIndex: node.dataset.windowIndex,
+      tabIndex: node.dataset.tabIndex,
+    })
+  );
+  event.dataTransfer.effectAllowed = "move";
+};
+
+const handleDragOver = (event) => {
+  event.preventDefault();
+  event.currentTarget.classList.add("drop-target");
+};
+
+const handleDragLeave = (event) => {
+  event.currentTarget.classList.remove("drop-target");
+};
+
+const handleDrop = async (event) => {
+  event.preventDefault();
+  event.currentTarget.classList.remove("drop-target");
+  const data = JSON.parse(event.dataTransfer.getData("text/plain"));
+  const targetNode = event.currentTarget;
+
+  if (data.sessionId !== targetNode.dataset.sessionId) {
+    return;
+  }
+
+  const session = sessions.find((item) => item.id === data.sessionId);
+  if (!session) {
+    return;
+  }
+
+  if (data.nodeType === "window" && targetNode.dataset.node === "window") {
+    const fromIndex = Number(data.windowIndex);
+    const toIndex = Number(targetNode.dataset.windowIndex);
+    const [moved] = session.windows.splice(fromIndex, 1);
+    session.windows.splice(toIndex, 0, moved);
+  }
+
+  if (data.nodeType === "tab") {
+    const fromWindowIndex = Number(data.windowIndex);
+    const fromTabIndex = Number(data.tabIndex);
+    const [moved] = session.windows[fromWindowIndex].tabs.splice(
+      fromTabIndex,
+      1
+    );
+    if (targetNode.dataset.node === "tab") {
+      const toWindowIndex = Number(targetNode.dataset.windowIndex);
+      const toTabIndex = Number(targetNode.dataset.tabIndex);
+      session.windows[toWindowIndex].tabs.splice(toTabIndex, 0, moved);
+    } else if (targetNode.dataset.node === "window") {
+      const toWindowIndex = Number(targetNode.dataset.windowIndex);
+      session.windows[toWindowIndex].tabs.push(moved);
+    }
+  }
+
+  await saveSessions(sessions);
+  renderSessions();
+};
+
+const attachEventHandlers = () => {
+  sessionList.addEventListener("click", (event) => {
+    const target = event.target;
+    if (target.matches("button[data-action]")) {
+      handleAction(target.dataset.action, target);
+    }
+  });
+
+  selectAll.addEventListener("change", (event) => {
+    const checked = event.target.checked;
+    document
+      .querySelectorAll("input[type='checkbox']")
+      .forEach((input) => {
+        input.checked = checked;
+        input.indeterminate = false;
+      });
+  });
+
+  saveButton.addEventListener("click", async () => {
+    const session = await buildSession("Manual Save");
+    sessions.unshift(session);
+    await saveSessions(sessions);
+    renderSessions();
+  });
+
+  restoreSelectedButton.addEventListener("click", restoreSelected);
+  deleteSelectedButton.addEventListener("click", deleteSelected);
+  closeSelectedButton.addEventListener("click", closeSelected);
+
+  exportJsonButton.addEventListener("click", () => {
+    const blob = new Blob([JSON.stringify(sessions, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "sessions.json";
+    link.click();
+    URL.revokeObjectURL(url);
+  });
+
+  importJsonInput.addEventListener("change", async (event) => {
+    const file = event.target.files[0];
+    if (!file) {
+      return;
+    }
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) {
+      sessions = parsed;
+      await saveSessions(sessions);
+      renderSessions();
+    }
+    importJsonInput.value = "";
+  });
+};
+
+const init = async () => {
+  sessions = await getSessions();
+  renderSessions();
+  attachEventHandlers();
+  if (!isExtensionEnv) {
+    saveButton.disabled = true;
+    restoreSelectedButton.disabled = true;
+    deleteSelectedButton.disabled = true;
+    closeSelectedButton.disabled = true;
+  }
+};
+
+init();

--- a/session.js
+++ b/session.js
@@ -163,9 +163,12 @@ const createSessionNode = (session, index) => {
 
   const title = document.createElement("div");
   title.className = "title";
-  title.textContent = `${session.name} • ${new Date(
+  const titleText = document.createElement("span");
+  titleText.className = "node-title";
+  titleText.textContent = `${session.name} • ${new Date(
     session.createdAt
   ).toLocaleString()}`;
+  title.appendChild(titleText);
 
   const actions = document.createElement("div");
   actions.className = "node-actions";
@@ -220,7 +223,10 @@ const createWindowNode = (session, window, windowIndex) => {
 
   const title = document.createElement("div");
   title.className = "title";
-  title.textContent = `${window.title} (${window.tabs.length} tabs)`;
+  const titleText = document.createElement("span");
+  titleText.className = "node-title";
+  titleText.textContent = `${window.title} (${window.tabs.length} tabs)`;
+  title.appendChild(titleText);
 
   const actions = document.createElement("div");
   actions.className = "node-actions";
@@ -279,6 +285,7 @@ const createTabNode = (session, tab, windowIndex, tabIndex) => {
   favicon.src = tab.favIconUrl || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Crect width='16' height='16' rx='4' fill='%23cbd2d9'/%3E%3C/svg%3E";
   favicon.alt = "";
   const text = document.createElement("span");
+  text.className = "tab-title";
   text.textContent = tab.title || "Untitled Tab";
   const link = document.createElement("a");
   link.href = tab.url || "#";

--- a/session.js
+++ b/session.js
@@ -8,6 +8,7 @@ const deleteSelectedButton = document.getElementById("delete-selected");
 const closeSelectedButton = document.getElementById("close-selected");
 const exportJsonButton = document.getElementById("export-json");
 const importJsonInput = document.getElementById("import-json");
+const toolbar = document.querySelector(".toolbar");
 
 let sessions = [];
 const isExtensionEnv =
@@ -613,11 +614,60 @@ const handleDrop = async (event) => {
   renderSessions();
 };
 
+const updateToggleState = (node, collapsed) => {
+  const children = node.querySelector(":scope > .children");
+  if (!children) {
+    return;
+  }
+  const toggle = node.querySelector(":scope .toggle");
+  if (collapsed) {
+    children.classList.add("collapsed");
+  } else {
+    children.classList.remove("collapsed");
+  }
+  if (toggle) {
+    toggle.textContent = children.classList.contains("collapsed") ? "▸" : "▾";
+  }
+};
+
+const toggleLevel = (mode, level) => {
+  const collapsed = mode === "collapse";
+  if (level === "all") {
+    sessionList
+      .querySelectorAll("[data-node='session'], [data-node='window']")
+      .forEach((node) => updateToggleState(node, collapsed));
+    return;
+  }
+  if (level === "windows") {
+    sessionList
+      .querySelectorAll("[data-node='session']")
+      .forEach((node) => updateToggleState(node, collapsed));
+    return;
+  }
+  if (level === "tabs") {
+    sessionList
+      .querySelectorAll("[data-node='window']")
+      .forEach((node) => updateToggleState(node, collapsed));
+  }
+};
+
 const attachEventHandlers = () => {
   sessionList.addEventListener("click", (event) => {
     const target = event.target.closest("button[data-action]");
     if (target) {
       handleAction(target.dataset.action, target);
+    }
+  });
+
+  toolbar?.addEventListener("click", (event) => {
+    const expandButton = event.target.closest("button[data-expand]");
+    if (expandButton) {
+      toggleLevel("expand", expandButton.dataset.expand);
+      return;
+    }
+    const collapseButton = event.target.closest("button[data-collapse]");
+    if (collapseButton) {
+      toggleLevel("collapse", collapseButton.dataset.collapse);
     }
   });
 


### PR DESCRIPTION
### Motivation
- Provide an extension that automatically captures browser windows and tabs as sessions and lets users manage them after quit or restart. 
- Offer a readable, interactive tree view so users can selectively restore, delete, close, or move sessions, windows, and tabs. 
- Support drag-and-drop reordering and window/tab moves plus import/export to JSON for portability and backup. 
- Allow previewing the UI outside of the extension environment with a fallback dataset.

### Description
- Added `manifest.json` and `background.js` which auto-save sessions (using `chrome.storage.local`, `onStartup`, and `onSuspend`), enforce `MAX_SESSIONS`, and open/focus `session.html` from the extension action. 
- Added `session.html`, `session.css`, and `session.js` implementing an expandable/collapsible tree view with checkboxes, per-node `Restore/Delete/Close` buttons, drag-and-drop reordering/moving, and file `Import/Export JSON` controls. 
- Implemented persistence and session building logic that stores sessions as JSON (tab title, URL, and favicon), and restore/close operations that use stored URLs to recreate or close windows/tabs. 
- Added a preview-friendly runtime check (`isExtensionEnv`) to show sample data and disable extension-only actions when the page is opened outside a Chrome extension.

### Testing
- Started a local HTTP server and rendered `session.html` with Playwright to capture a full-page screenshot, which completed successfully and produced `artifacts/session-manager.png`. 
- The page renders a sample session when `chrome` APIs are not available, and extension-specific actions are disabled in that mode. 
- No unit tests were added for this change. 
- All automated steps executed during the rollout (local server + Playwright render) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d28d6c2a88331804ab3ac2d8e35b8)